### PR TITLE
Allow to specify client url as an absolute url

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
@@ -30,7 +30,8 @@ public class CXFRecorder {
                 String cfgSei = cxfEndPointConfig.serviceInterface.get();
                 if (cfgSei.equals(sei)) {
                     String endpointAddress = cxfEndPointConfig.clientEndpointUrl.orElse("http://localhost:8080");
-                    if (!relativePath.equals("/") && !relativePath.equals("")) {
+                    boolean clientEndpointAbsoluteUrl = cxfEndPointConfig.clientEndpointAbsoluteUrl.orElse(false);
+                    if (!clientEndpointAbsoluteUrl && !relativePath.equals("/") && !relativePath.equals("")) {
                         endpointAddress = endpointAddress.endsWith("/")
                                 ? endpointAddress.substring(0, endpointAddress.length() - 1)
                                 : endpointAddress;

--- a/runtime/src/main/java/io/quarkiverse/cxf/CxfEndpointConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/CxfEndpointConfig.java
@@ -28,6 +28,12 @@ public class CxfEndpointConfig {
     public Optional<String> clientEndpointUrl;
 
     /**
+     * Specifies whether the clientEndpointUrl is an absolute url
+     */
+    @ConfigItem
+    public Optional<Boolean> clientEndpointAbsoluteUrl;
+
+    /**
      * The server endpoint url
      */
     @ConfigItem


### PR DESCRIPTION
In my opinion current approach when specifying the client url is a bit confusing.

```
quarkus.cxf.endpoint."/foo".client-endpoint-url=http://localhost:8081/soap/greeting
```
This configuration requires that the part `/foo` is constant. And if that suffix changes, it is necessary to modify all config entries to accommodate that change.

I think the ability to specify the absolute url of the client service could be useful in some cases - especially if that url needs to be dynamically set e.g via an environment variable.

Looking forward to your thoughts on that (or maybe I missed some obvious solution with the current impelmentation?).