### PR TITLE
Opentracing feature & interceptors, compatible with quarkus

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -66,6 +66,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/runtime/src/main/java/io/quarkiverse/cxf/tracing/AbstractOpenTracingInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/tracing/AbstractOpenTracingInterceptor.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.cxf.tracing;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.PhaseInterceptor;
+
+import io.opentracing.Tracer;
+
+public abstract class AbstractOpenTracingInterceptor extends AbstractOpenTracingProvider
+        implements PhaseInterceptor<Message> {
+
+    private final String phase;
+
+    protected AbstractOpenTracingInterceptor(String phase, Tracer tracer) {
+        super(tracer);
+        this.phase = phase;
+    }
+
+    @Override
+    public Set<String> getAfter() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> getBefore() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getId() {
+        return this.getClass().getName();
+    }
+
+    @Override
+    public String getPhase() {
+        return this.phase;
+    }
+
+    @Override
+    public Collection<PhaseInterceptor<? extends Message>> getAdditionalInterceptors() {
+        return null;
+    }
+
+    @Override
+    public void handleFault(Message message) {
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/cxf/tracing/AbstractOpenTracingProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/tracing/AbstractOpenTracingProvider.java
@@ -1,0 +1,97 @@
+package io.quarkiverse.cxf.tracing;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format.Builtin;
+import io.opentracing.tag.Tags;
+
+public abstract class AbstractOpenTracingProvider extends AbstractTracingProvider {
+    protected static final Logger LOG = LogUtils.getL7dLogger(AbstractOpenTracingProvider.class);
+    protected static final String TRACE_SPAN = "org.apache.cxf.tracing.opentracing.span";
+
+    protected final Tracer tracer;
+
+    protected AbstractOpenTracingProvider(final Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    protected TraceScopeHolder<TraceScope> startTraceSpan(final Map<String, List<String>> requestHeaders,
+            URI uri, String method) {
+
+        final SpanContext parent = this.tracer.extract(Builtin.HTTP_HEADERS,
+                new HeaderExtractAdapter(requestHeaders));
+
+        Span activeSpan = null;
+        Scope scope = null;
+        if (parent == null) {
+            activeSpan = this.tracer.buildSpan(this.buildSpanDescription(uri.getPath(), method)).start();
+            scope = this.tracer.scopeManager().activate(activeSpan, false);
+        } else {
+            activeSpan = this.tracer.buildSpan(this.buildSpanDescription(uri.getPath(), method)).asChildOf(parent).start();
+            scope = this.tracer.scopeManager().activate(activeSpan, false);
+        }
+
+        // Set additional tags
+        activeSpan.setTag(Tags.HTTP_METHOD.getKey(), method);
+        activeSpan.setTag(Tags.HTTP_URL.getKey(), uri.toString());
+
+        // If the service resource is using asynchronous processing mode, the trace
+        // scope will be closed in another thread and as such should be detached.
+        Span span = null;
+        if (this.isAsyncResponse()) {
+            // Do not modify the current context span
+            span = activeSpan;
+            this.propagateContinuationSpan(span);
+            scope.close();
+        }
+
+        return new TraceScopeHolder<>(new TraceScope(activeSpan, scope), span != null);
+    }
+
+    protected void stopTraceSpan(final Map<String, List<String>> requestHeaders,
+            final Map<String, List<Object>> responseHeaders,
+            final int responseStatus,
+            final TraceScopeHolder<TraceScope> holder) {
+
+        if (holder == null) {
+            return;
+        }
+
+        final TraceScope traceScope = holder.getScope();
+        if (traceScope != null) {
+            final Span span = traceScope.getSpan();
+            Scope scope = traceScope.getScope();
+
+            // If the service resource is using asynchronous processing mode, the trace
+            // scope has been created in another thread and should be re-attached to the current
+            // one.
+            if (holder.isDetached()) {
+                scope = this.tracer.scopeManager().activate(span, false);
+            }
+
+            span.setTag(Tags.HTTP_STATUS.getKey(), responseStatus);
+            span.setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+            span.finish();
+
+            scope.close();
+        }
+    }
+
+    protected boolean isAsyncResponse() {
+        return !PhaseInterceptorChain.getCurrentMessage().getExchange().isSynchronous();
+    }
+
+    private void propagateContinuationSpan(final Span continuation) {
+        PhaseInterceptorChain.getCurrentMessage().put(Span.class, continuation);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/cxf/tracing/AbstractTracingProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/tracing/AbstractTracingProvider.java
@@ -1,0 +1,101 @@
+package io.quarkiverse.cxf.tracing;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+
+public abstract class AbstractTracingProvider {
+    protected static String getSpanIdHeader() {
+        return getHeaderOrDefault("org.apache.cxf.tracing.header.span_id", "X-Span-Id");
+    }
+
+    protected static class TraceScopeHolder<T> implements Serializable {
+        private static final long serialVersionUID = -5985783659818936359L;
+
+        private final T scope;
+        private final boolean detached;
+
+        public TraceScopeHolder(final T scope, final boolean detached) {
+            this.scope = scope;
+            this.detached = detached;
+        }
+
+        public T getScope() {
+            return this.scope;
+        }
+
+        public boolean isDetached() {
+            return this.detached;
+        }
+    }
+
+    private static String getHeaderOrDefault(final String property, final String fallback) {
+        final Message message = PhaseInterceptorChain.getCurrentMessage();
+
+        if (message != null) {
+            final Object header = message.getContextualProperty(property);
+
+            if (header instanceof String) {
+                final String name = (String) header;
+                if (!StringUtils.isEmpty(name)) {
+                    return name;
+                }
+            }
+        }
+
+        return fallback;
+    }
+
+    protected String buildSpanDescription(final String path, final String method) {
+        if (StringUtils.isEmpty(method)) {
+            return path;
+        }
+        return method + " " + path;
+    }
+
+    private static String safeGet(Message message, String key) {
+        if (!message.containsKey(key)) {
+            return null;
+        }
+        final Object value = message.get(key);
+        return (value instanceof String) ? value.toString() : null;
+    }
+
+    private static String getUriAsString(Message message) {
+        String uri = safeGet(message, Message.REQUEST_URL);
+
+        if (uri == null) {
+            String address = safeGet(message, Message.ENDPOINT_ADDRESS);
+            uri = safeGet(message, Message.REQUEST_URI);
+            if (uri != null && uri.startsWith("/")) {
+                if (address != null && !address.startsWith(uri)) {
+                    if (address.endsWith("/") && address.length() > 1) {
+                        address = address.substring(0, address.length());
+                    }
+                    uri = address + uri;
+                }
+            } else {
+                uri = address;
+            }
+        }
+        final String query = safeGet(message, Message.QUERY_STRING);
+        if (query != null) {
+            return uri + "?" + query;
+        }
+
+        return uri;
+    }
+
+    protected static URI getUri(Message message) {
+        try {
+            final String uriSt = getUriAsString(message);
+            return uriSt != null ? new URI(uriSt) : new URI("");
+        } catch (final URISyntaxException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/cxf/tracing/HeaderExtractAdapter.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/tracing/HeaderExtractAdapter.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.cxf.tracing;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import io.opentracing.propagation.TextMap;
+
+public class HeaderExtractAdapter implements TextMap {
+
+    private final Map<String, List<String>> headers;
+
+    public HeaderExtractAdapter(Map<String, List<String>> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return new MultivaluedMapFlatIterator<>(this.headers.entrySet());
+    }
+
+    @Override
+    public void put(String key, String value) {
+        throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
+    }
+
+    protected Map<String, List<String>> servletHeadersToMultiMap(HttpServletRequest httpServletRequest) {
+        final Map<String, List<String>> headersResult = new HashMap<>();
+
+        final Enumeration<String> headerNamesIt = httpServletRequest.getHeaderNames();
+        while (headerNamesIt.hasMoreElements()) {
+            final String headerName = headerNamesIt.nextElement();
+
+            final Enumeration<String> valuesIt = httpServletRequest.getHeaders(headerName);
+            final List<String> valuesList = new ArrayList<>(1);
+            while (valuesIt.hasMoreElements()) {
+                valuesList.add(valuesIt.nextElement());
+            }
+
+            headersResult.put(headerName, valuesList);
+        }
+
+        return headersResult;
+    }
+
+    public static final class MultivaluedMapFlatIterator<K, V> implements Iterator<Map.Entry<K, V>> {
+
+        private final Iterator<Map.Entry<K, List<V>>> mapIterator;
+        private Map.Entry<K, List<V>> mapEntry;
+        private Iterator<V> listIterator;
+
+        public MultivaluedMapFlatIterator(Set<Map.Entry<K, List<V>>> multiValuesEntrySet) {
+            this.mapIterator = multiValuesEntrySet.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (this.listIterator != null && this.listIterator.hasNext()) {
+                return true;
+            }
+
+            return this.mapIterator.hasNext();
+        }
+
+        @Override
+        public Map.Entry<K, V> next() {
+            if (this.mapEntry == null || (!this.listIterator.hasNext() && this.mapIterator.hasNext())) {
+                this.mapEntry = this.mapIterator.next();
+                this.listIterator = this.mapEntry.getValue().iterator();
+            }
+
+            if (this.listIterator.hasNext()) {
+                return new AbstractMap.SimpleImmutableEntry<>(this.mapEntry.getKey(), this.listIterator.next());
+            } else {
+                return new AbstractMap.SimpleImmutableEntry<>(this.mapEntry.getKey(), null);
+            }
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/cxf/tracing/OpenTracingFeature.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/tracing/OpenTracingFeature.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.cxf.tracing;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.annotations.Provider;
+import org.apache.cxf.annotations.Provider.Scope;
+import org.apache.cxf.annotations.Provider.Type;
+import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
+
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+
+@NoJSR250Annotations
+@Provider(value = Type.Feature, scope = Scope.Server)
+public class OpenTracingFeature extends DelegatingFeature<OpenTracingFeature.Portable> {
+    public OpenTracingFeature() {
+        super(new Portable());
+    }
+
+    public OpenTracingFeature(final Tracer tracer) {
+        super(new Portable(tracer));
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        private final OpenTracingStartInterceptor in;
+        private final OpenTracingStopInterceptor out;
+
+        public Portable() {
+            this(GlobalTracer.get());
+        }
+
+        public Portable(final Tracer tracer) {
+            this.in = new OpenTracingStartInterceptor(tracer);
+            this.out = new OpenTracingStopInterceptor(tracer);
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            provider.getInInterceptors().add(this.in);
+            provider.getInFaultInterceptors().add(this.in);
+
+            provider.getOutInterceptors().add(this.out);
+            provider.getOutFaultInterceptors().add(this.out);
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/cxf/tracing/OpenTracingStartInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/tracing/OpenTracingStartInterceptor.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.cxf.tracing;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.Phase;
+
+import io.opentracing.Tracer;
+
+@NoJSR250Annotations
+public class OpenTracingStartInterceptor extends AbstractOpenTracingInterceptor {
+    public OpenTracingStartInterceptor(Tracer tracer) {
+        super(Phase.PRE_INVOKE, tracer);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        final Map<String, List<String>> headers = CastUtils.cast((Map<?, ?>) message.get(Message.PROTOCOL_HEADERS));
+
+        final TraceScopeHolder<TraceScope> holder = super.startTraceSpan(headers,
+                getUri(message), (String) message.get(Message.HTTP_REQUEST_METHOD));
+
+        if (holder != null) {
+            message.getExchange().put(TRACE_SPAN, holder);
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/cxf/tracing/OpenTracingStopInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/tracing/OpenTracingStopInterceptor.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.cxf.tracing;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
+import org.apache.cxf.phase.Phase;
+
+import io.opentracing.Tracer;
+
+public class OpenTracingStopInterceptor extends AbstractOpenTracingInterceptor {
+    public OpenTracingStopInterceptor(final Tracer tracer) {
+        super(Phase.POST_MARSHAL, tracer);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        Map<String, List<Object>> responseHeaders = CastUtils.cast((Map<?, ?>) message.get(Message.PROTOCOL_HEADERS));
+
+        if (responseHeaders == null) {
+            responseHeaders = new HashMap<>();
+            message.put(Message.PROTOCOL_HEADERS, responseHeaders);
+        }
+
+        final boolean isRequestor = MessageUtils.isRequestor(message);
+        final Message requestMessage = isRequestor ? message.getExchange().getOutMessage()
+                : message.getExchange().getInMessage();
+        final Map<String, List<String>> requestHeaders = CastUtils
+                .cast((Map<?, ?>) requestMessage.get(Message.PROTOCOL_HEADERS));
+
+        @SuppressWarnings("unchecked")
+        final TraceScopeHolder<TraceScope> holder = (TraceScopeHolder<TraceScope>) message.getExchange().get(TRACE_SPAN);
+
+        Integer responseCode = (Integer) message.get(Message.RESPONSE_CODE);
+        if (responseCode == null) {
+            responseCode = 200;
+        }
+
+        super.stopTraceSpan(requestHeaders, responseHeaders, responseCode, holder);
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/cxf/tracing/TraceScope.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/tracing/TraceScope.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.cxf.tracing;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+
+public class TraceScope {
+    private final Span span;
+    private final Scope scope;
+
+    TraceScope(final Span span, final Scope scope) {
+        this.span = span;
+        this.scope = scope;
+    }
+
+    public Span getSpan() {
+        return this.span;
+    }
+
+    public Scope getScope() {
+        return this.scope;
+    }
+}


### PR DESCRIPTION
Quarkus and cxf are implementing two different versions of opentracing api:
0.31.0 for quarkus and 0.33.0 for cxf.

I am here adapting the code of cxf-integration-tracing-opentracing so that it complies with the 0.31.0.
It can then be removed when quarkus is aligned to 0.33.0.

The change compared to the original code is only in io.quarkiverse.cxf.tracing.AbstractOpenTracingProvider.startTraceSpan(Map<String, List<String>>, URI, String), using the HeaderExtractAdapter instead of the TextMapAdapter.
