### PR TITLE
Drop obsolete undertow dependencies

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -23,10 +23,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
         </dependency>
         <dependency>

--- a/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -869,8 +869,6 @@ class QuarkusCxfProcessor {
                 "com.sun.xml.ws.runtime.config.ObjectFactory",
                 "ibm.wsdl.DefinitionImpl",
                 "io.swagger.jaxrs.DefaultParameterExtension",
-                "io.undertow.server.HttpServerExchange",
-                "io.undertow.UndertowOptions",
                 "java.lang.invoke.MethodHandles",
                 "java.rmi.RemoteException",
                 "java.rmi.ServerException",

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -27,10 +27,6 @@
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -43,10 +43,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
         <dependency>

--- a/runtime/src/main/java/io/quarkiverse/cxf/transport/VertxServletOutputStream.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/transport/VertxServletOutputStream.java
@@ -9,8 +9,8 @@ import javax.servlet.WriteListener;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.undertow.httpcore.HttpHeaderNames;
-import io.undertow.vertx.VertxBufferImpl;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.quarkus.vertx.core.runtime.VertxBufferImpl;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;


### PR DESCRIPTION
Fixes #197

I'm not 100% sure what was happening but I guess the `servlet`/`undertow` extension got in the way with the path resolution once `resteasy-reactive` is in the mix.
That might have something to do with https://quarkus.io/guides/all-config#quarkus-undertow_quarkus.servlet.context-path

This was actually a lucky punch since at first I was merely wondering why this extension is still bringing in the `servlet` extension, given that #37 was implemented quite some time ago.