### PR TITLE
Dependabot: ignore jakarta.xml.ws-api >= 3.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: jakarta.xml.ws:jakarta.xml.ws-api
+        versions:
+          - ">= 3.0.0"


### PR DESCRIPTION
Should prevent PRs like #200