### PR TITLE
Fix build failure on JDK 1.8

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientGreetingClientTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientGreetingClientTest.java
@@ -7,7 +7,6 @@ import java.lang.reflect.Proxy;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.xml.ws.WebServiceException;
-import javax.xml.ws.soap.SOAPFaultException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientGreetingClientTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientGreetingClientTest.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Proxy;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.xml.ws.WebServiceException;
 import javax.xml.ws.soap.SOAPFaultException;
 
 import org.junit.jupiter.api.Assertions;
@@ -86,7 +87,7 @@ class ClientGreetingClientTest {
 
     @Test
     public void testOutInterceptorPresent() {
-        Assertions.assertThrows(SOAPFaultException.class, () -> {
+        Assertions.assertThrows(WebServiceException.class, () -> {
             faultyClient.ping("hello");
         });
     }


### PR DESCRIPTION
Fixes #222 - build is OK with both JDK 1.8 and 11 with this change.