### PR TITLE
Ban bind-api and asm from runtime module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,6 @@
                 <version>${cxf.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.xml.soap</groupId>
-                        <artifactId>javax.xml.soap-api</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>jakarta.xml.bind</groupId>
                         <artifactId>jakarta.xml.bind-api</artifactId>
                     </exclusion>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -83,6 +83,28 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-runtime-dependencies</id>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
+                                        <exclude>org.ow2.asm:asm</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Those are excluded since a while in root pom but are required for the deployment module (coming from other dependencies).

I removed the exclusion for `javax.xml.soap-api` since that didn't do anything, `cxf-rt-frontend-jaxws` does not depend on this (anymore?).