### PR TITLE
Drop Java 8, move on to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,9 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <supported-maven.versions>[3.6.2,)</supported-maven.versions>
 


### PR DESCRIPTION
Quarkus 2 dropped Java 8 and moved on to Java 11, so there is no use sticking to 8 for this extension.