### PR TITLE
Limit client generation to only those portTypes that are actually used

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientConstructorInjectionBean.java
+++ b/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientConstructorInjectionBean.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.cxf.deployment.test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.quarkiverse.cxf.CXFClientInfo;
+import io.quarkiverse.cxf.annotation.CXFClient;
+
+@ApplicationScoped
+public class CxfClientConstructorInjectionBean {
+
+    private final CXFClientInfo clientInfo;
+    private final FruitWebService clientProxy;
+
+    @Inject
+    public CxfClientConstructorInjectionBean(
+            // @Named is omitted here because not required
+            CXFClientInfo clientInfo,
+            @CXFClient FruitWebService clientProxy) {
+        this.clientInfo = clientInfo;
+        this.clientProxy = clientProxy;
+    }
+
+    public CXFClientInfo getClientInfo() {
+        return clientInfo;
+    }
+
+    public FruitWebService getClientProxy() {
+        return clientProxy;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientConstructorInjectionInstanceBean.java
+++ b/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientConstructorInjectionInstanceBean.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.cxf.deployment.test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import io.quarkiverse.cxf.CXFClientInfo;
+import io.quarkiverse.cxf.annotation.CXFClient;
+
+@ApplicationScoped
+public class CxfClientConstructorInjectionInstanceBean {
+
+    private final Instance<CXFClientInfo> clientInfoInstance;
+    private final Instance<FruitWebService> clientProxyInstance;
+
+    @Inject
+    public CxfClientConstructorInjectionInstanceBean(
+            // @Named is omitted here because not required
+            Instance<CXFClientInfo> clientInfoInstance,
+            @CXFClient Instance<FruitWebService> clientProxyInstance) {
+        this.clientInfoInstance = clientInfoInstance;
+        this.clientProxyInstance = clientProxyInstance;
+    }
+
+    public Instance<CXFClientInfo> getClientInfoInstance() {
+        return clientInfoInstance;
+    }
+
+    public Instance<FruitWebService> getClientProxyInstance() {
+        return clientProxyInstance;
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientConstructorInjectionInstanceTest.java
+++ b/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientConstructorInjectionInstanceTest.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.cxf.deployment.test;
+
+import java.lang.reflect.Proxy;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.cxf.CXFClientInfo;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CxfClientConstructorInjectionInstanceTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class)
+                    .addClass(CxfClientConstructorInjectionInstanceBean.class))
+            .withConfigurationResource("application-cxf-test.properties");
+
+    @Inject
+    CxfClientConstructorInjectionInstanceBean bean;
+
+    @Test
+    public void testInjectedInstances() {
+        Instance<CXFClientInfo> clientInfoInstance = bean.getClientInfoInstance();
+        Instance<FruitWebService> clientProxyInstance = bean.getClientProxyInstance();
+
+        Assertions.assertNotNull(clientInfoInstance);
+        Assertions.assertNotNull(clientProxyInstance);
+
+        Assertions.assertTrue(clientInfoInstance.isResolvable());
+        Assertions.assertTrue(clientProxyInstance.isResolvable());
+
+        Assertions.assertFalse(Proxy.isProxyClass(clientInfoInstance.get().getClass()));
+        Assertions.assertTrue(Proxy.isProxyClass(clientProxyInstance.get().getClass()));
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientConstructorInjectionTest.java
+++ b/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientConstructorInjectionTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.cxf.deployment.test;
+
+import java.lang.reflect.Proxy;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CxfClientConstructorInjectionTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class)
+                    .addClass(CxfClientConstructorInjectionBean.class))
+            .withConfigurationResource("application-cxf-test.properties");
+
+    @Inject
+    CxfClientConstructorInjectionBean bean;
+
+    @Test
+    public void testInjectedBeans() {
+        Assertions.assertNotNull(bean.getClientInfo());
+        Assertions.assertNotNull(bean.getClientProxy());
+
+        Assertions.assertFalse(Proxy.isProxyClass(bean.getClientInfo().getClass()));
+        Assertions.assertTrue(Proxy.isProxyClass(bean.getClientProxy().getClass()));
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfClientTest.java
@@ -3,7 +3,6 @@ package io.quarkiverse.cxf.deployment.test;
 import java.lang.reflect.Proxy;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -30,7 +29,6 @@ public class CxfClientTest {
             .withConfigurationResource("application-cxf-test.properties");
 
     @Inject
-    @Named("io.quarkiverse.cxf.deployment.test.FruitWebService")
     CXFClientInfo clientInfo;
 
     @Inject

--- a/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfSeiOnlyClientInstanceTest.java
+++ b/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfSeiOnlyClientInstanceTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.cxf.deployment.test;
 
 import java.lang.reflect.Proxy;
 
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -16,7 +17,7 @@ import io.quarkiverse.cxf.CXFClientInfo;
 import io.quarkiverse.cxf.annotation.CXFClient;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class CxfSeiOnlyClientTest {
+public class CxfSeiOnlyClientInstanceTest {
 
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
@@ -27,25 +28,31 @@ public class CxfSeiOnlyClientTest {
             .withConfigurationResource("application-cxf-test.properties");
 
     @Inject
-    CXFClientInfo clientInfo;
+    Instance<CXFClientInfo> clientInfoInstance;
 
     @Inject
     @Named("io.quarkiverse.cxf.deployment.test.FruitWebService")
-    CXFClientInfo namedClientInfo;
+    Instance<CXFClientInfo> namedClientInfoInstance;
 
     @Inject
     @CXFClient
-    FruitWebService clientProxy;
+    Instance<FruitWebService> clientProxyinstance;
 
     @Test
-    public void testInjectedBeans() {
+    public void testInjectedInstances() {
+        Assertions.assertTrue(clientInfoInstance.isResolvable());
+        Assertions.assertTrue(clientProxyinstance.isResolvable());
+
+        CXFClientInfo clientInfo = clientInfoInstance.get();
+        FruitWebService clientProxy = clientProxyinstance.get();
+
         Assertions.assertNotNull(clientInfo);
         Assertions.assertNotNull(clientProxy);
 
         Assertions.assertFalse(Proxy.isProxyClass(clientInfo.getClass()));
         Assertions.assertTrue(Proxy.isProxyClass(clientProxy.getClass()));
 
-        Assertions.assertEquals(namedClientInfo, clientInfo);
+        Assertions.assertEquals(namedClientInfoInstance.get(), clientInfo);
     }
 
     @Test


### PR DESCRIPTION
Resolves #252

Includes some cleanups and refactorings to QuarkusCxfProcessor.

Also introduces tests that check constructor and instance injection.

A general note: I tried to reduce the number of local variables in the processor to make the code more readable (IMO).