### PR TITLE
Fix invalid import URLs in WSDLs

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/XForwardedHeadersTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/XForwardedHeadersTest.java
@@ -40,7 +40,7 @@ public class XForwardedHeadersTest {
                 .get("/soap/greeting?wsdl")
                 .then()
                 .statusCode(200)
-                .body(containsString("http://localhost:8081/test/soap/greeting?wsdl"));
+                .body(containsString("http://localhost:8081/test/soap/greeting"));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class XForwardedHeadersTest {
                 .get("/soap/greeting?wsdl")
                 .then()
                 .statusCode(200)
-                .body(containsString("https://localhost/soap/greeting?wsdl"));
+                .body(containsString("https://localhost/soap/greeting"));
     }
 
     @Test
@@ -64,7 +64,7 @@ public class XForwardedHeadersTest {
                 .get("/soap/greeting?wsdl")
                 .then()
                 .statusCode(200)
-                .body(containsString("http://api.example.com:8081/soap/greeting?wsdl"));
+                .body(containsString("http://api.example.com:8081/soap/greeting"));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class XForwardedHeadersTest {
                 .get("/soap/greeting?wsdl")
                 .then()
                 .statusCode(200)
-                .body(containsString("http://localhost:443/soap/greeting?wsdl"));
+                .body(containsString("http://localhost:443/soap/greeting"));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class XForwardedHeadersTest {
                 .get("/soap/greeting?wsdl")
                 .then()
                 .statusCode(200)
-                .body(containsString("https://api.example.com:443/test/soap/greeting?wsdl"));
+                .body(containsString("https://api.example.com:443/test/soap/greeting"));
     }
 
     @Test
@@ -122,10 +122,10 @@ public class XForwardedHeadersTest {
 
         for (Response response : responses) {
             response.then().body(CoreMatchers.anyOf(
-                    containsString("http://api1.example.com:8081/soap/greeting?wsdl"),
-                    containsString("http://localhost:443/soap/greeting?wsdl"),
-                    containsString("http://localhost:8081/test/soap/greeting?wsdl"),
-                    containsString("https://localhost:8280/soap/greeting?wsdl")));
+                    containsString("http://api1.example.com:8081/soap/greeting"),
+                    containsString("http://localhost:443/soap/greeting"),
+                    containsString("http://localhost:8081/test/soap/greeting"),
+                    containsString("https://localhost:8280/soap/greeting")));
         }
     }
 

--- a/runtime/src/main/java/io/quarkiverse/cxf/transport/VertxHttpServletRequest.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/transport/VertxHttpServletRequest.java
@@ -449,7 +449,9 @@ public class VertxHttpServletRequest implements HttpServletRequest {
 
     @Override
     public StringBuffer getRequestURL() {
-        return new StringBuffer(request.absoluteURI());
+        String absoluteUri = request.absoluteURI();
+        String urlWithoutParams = absoluteUri.replaceFirst("\\?.*$", "");
+        return new StringBuffer(urlWithoutParams);
     }
 
     @Override


### PR DESCRIPTION
Fixes #323 and #345.

@famod Please have a quick review.  The core issue was that `getRequestURL()` was returning the URL with query parameters in it; it should have been without.  This was a tricky one to figure out.

This not only fixes the issues with the XSD imports, but also the service address location should appear correctly in the WSDLs now, as shown below, without any query parameters (eg. ?wsdl) in it.

```xml
<wsdl:service name="CxftestSoapService">
    <wsdl:port binding="tns:CxftestSoapBinding" name="CxftestServicePort">
        <soap:address location="http://localhost:8080/soap/CxftestSoapService"/>
    </wsdl:port>
</wsdl:service>
```