### PR TITLE
Reduce logging noise with focus on client mode

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/cxf/CxfClientProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/CxfClientProducer.java
@@ -82,9 +82,8 @@ public abstract class CxfClientProducer {
         bus.setExtension(new FactoryClassLoader(bus), FactoryClassCreator.class);
         bus.setExtension(new GeneratedNamespaceClassLoader(bus), NamespaceClassCreator.class);
         factory.setServiceClass(seiClass);
-        LOGGER.info(format("using servicename %s%s", cxfClientInfo.getWsNamespace(), cxfClientInfo.getWsName()));
+        LOGGER.debugf("using servicename {%s}%s", cxfClientInfo.getWsNamespace(), cxfClientInfo.getWsName());
         factory.setServiceName(new QName(cxfClientInfo.getWsNamespace(), cxfClientInfo.getWsName()));
-        LOGGER.info(format("using  servicename %s", factory.getServiceName()));
         if (cxfClientInfo.getEpName() != null) {
             factory.setEndpointName(new QName(cxfClientInfo.getEpNamespace(), cxfClientInfo.getEpName()));
         }
@@ -117,7 +116,7 @@ public abstract class CxfClientProducer {
             addToCols(inFaultInterceptor, factory.getInFaultInterceptors());
         }
 
-        LOGGER.info("cxf client loaded for " + cxfClientInfo.getSei());
+        LOGGER.debug("cxf client loaded for " + cxfClientInfo.getSei());
         return factory.create();
     }
 
@@ -137,7 +136,7 @@ public abstract class CxfClientProducer {
         try {
             cls = Class.forName(className, false, Thread.currentThread().getContextClassLoader()).asSubclass(clazz);
         } catch (ClassNotFoundException | ClassCastException e) {
-            LOGGER.warn(format("no such class %s", className));
+            LOGGER.warnf("no such class %s", className);
             return;
         }
         T item = null;
@@ -155,7 +154,7 @@ public abstract class CxfClientProducer {
         }
 
         if (item == null) {
-            LOGGER.warn(format("unable to create instance of class %s", className));
+            LOGGER.warnf("unable to create instance of class %s", className);
         } else {
             cols.add(item);
         }
@@ -221,9 +220,7 @@ public abstract class CxfClientProducer {
         // the service itself.
 
         if (keylist.isEmpty()) {
-            String fmt;
-            fmt = "no matching configuration found for SEI %s, using derived value %s.";
-            LOGGER.warn(format(fmt, meta.getSei(), meta));
+            LOGGER.warnf("no matching configuration found for SEI %s, using derived value %s.", meta.getSei(), meta);
             return meta;
         }
 


### PR DESCRIPTION
Motivation for this change is this noise when running a test in my project:
```
2022-01-28 18:22:08,331 INFO  [org.apa.cxf.wsd.ser.fac.ReflectionServiceFactoryBean] (build-2) Creating Service {http://xoev.de/transport/xta/211}MsgBoxPortTypeService from class de.xoev.transport.xta._211.MsgBoxPortType
2022-01-28 18:22:09,084 INFO  [io.qua.cxf.dep.QuarkusCxfProcessor] (build-6) producing dedicated CXFClientInfo bean named 'de.xoev.transport.xta._211.MsgBoxPortType' for SEI de.xoev.transport.xta._211.MsgBoxPortType
2022-01-28 18:22:17,331 INFO  [io.qua.sch.run.SimpleScheduler] (main) Simple scheduler is disabled by config property and will not be started
2022-01-28 18:22:17,335 INFO  [io.quarkus] (main) Quarkus 2.6.3.Final on JVM started in 10.685s.
2022-01-28 18:22:17,337 INFO  [io.quarkus] (main) Profile ext-test activated.
2022-01-28 18:22:17,338 INFO  [io.quarkus] (main) Installed features: [agroal, blaze-persistence, cdi, config-yaml, cxf, hibernate-orm, hibernate-orm-panache, hibernate-validator, jacoco, jdbc-h2, jdbc-mariadb, liquibase, narayana-jta, rest-client, scheduler, smallrye-context-propagation, spring-data-jpa, spring-di, vertx]
2022-01-28 18:22:17,523 INFO  [io.qua.cxf.CxfClientProducer] (main) using servicename http://xoev.de/transport/xta/211XTAService
2022-01-28 18:22:17,523 INFO  [io.qua.cxf.CxfClientProducer] (main) using  servicename {http://xoev.de/transport/xta/211}XTAService
2022-01-28 18:22:17,532 INFO  [io.qua.cxf.CxfClientProducer] (main) cxf client loaded for de.xoev.transport.xta._211.MsgBoxPortType
2022-01-28 18:22:17,534 INFO  [org.apa.cxf.wsd.ser.fac.ReflectionServiceFactoryBean] (main) Creating Service {http://xoev.de/transport/xta/211}XTAService from class de.xoev.transport.xta._211.MsgBoxPortTyp
```
I think there is even more potential, but we can improve on that later.