### PR TITLE
Docs cleanup: org.acme examples

### DIFF
--- a/docs/modules/ROOT/pages/client.adoc
+++ b/docs/modules/ROOT/pages/client.adoc
@@ -5,11 +5,11 @@ Quarkus-CXF supports SOAP clients. Assuming a given SEI like `FruitWebService`, 
 
 [source,java]
 ----
-import com.example.FruitWebService;                   // SEI
+import org.acme.FruitWebService;                   // SEI
 import javax.enterprise.context.ApplicationScoped;
 import io.quarkiverse.cxf.annotation.CXFClient;
 
-@Application  // or any other CDI scope
+@ApplicationScoped  // or any other CDI scope
 public class MySoapClient {
 
     @Inject @CXFClient
@@ -26,7 +26,7 @@ Without any further configuration Quarkus-CXF assumes a service to be published 
 * config property `quarkus.cxf.path` (if present); and the
 * SEI’s lowercased class name
 
-Given `quarkus.cxf.path=/ws`, Quarkus-CXF would use http://localhost:8080/ws/com.example.fruitwebservice as `FruitWebService` 's endpoint URL and otherwise just  http://localhost:8080/ws/com.example.fruitwebservice.
+Given `quarkus.cxf.path=/ws`, Quarkus-CXF would use http://localhost:8080/ws/org.acme.fruitwebservice as `FruitWebService` 's endpoint URL and otherwise just  http://localhost:8080/ws/org.acme.fruitwebservice.
 
 
 Various SOAP client properties can be configured. To do so, prefix `quarkus.cxf.client.{name}` creates a logical client configuration unit. The name of such a unit, here denoted as `{name}`, can be arbitrarily choosen as long as not (whitespace) empty. The following properties are available on such a configuration unit:
@@ -48,7 +48,7 @@ Various SOAP client properties can be configured. To do so, prefix `quarkus.cxf.
 A typical example configuration example is given below. Here unit name `my-fruitservice-client` is used. The goal of this configuration is the change the service endpoint address to http://localhost:8080/fruit:
 [source,properties]
 ----
-quarkus.cxf.client."my-fruitservice-client".service-interface=com.example.FruitWebService
+quarkus.cxf.client."my-fruitservice-client".service-interface=org.acme.FruitWebService
 quarkus.cxf.client."my-fruitservice-client".client-endpoint-url=http://localhost:8080/fruit
 ----
 
@@ -67,7 +67,7 @@ Default configurations must be unique per SEI while it is otherwise perfectly va
 
 [source,properties]
 ----
-quarkus.cxf.client."my-fruitservice-client".service-interface=com.example.FruitWebService
+quarkus.cxf.client."my-fruitservice-client".service-interface=org.acme.FruitWebService
 quarkus.cxf.client."my-fruitservice-client".client-endpoint-url=http://localhost:8080/fruit
 
 quarkus.cxf.client."my-featured-fruitservice-client".client-endpoint-url=http://localhost:8080/fruit
@@ -79,11 +79,11 @@ Here a second configuration named `my-featured-fruitservice-client` has been def
 be useful for tracing or debugging. An example for the purpose of illustration:
 [source,java]
 ----
-import com.example.FruitWebService;
+import org.acme.FruitWebService;
 import javax.enterprise.context.ApplicationScoped;
 import io.quarkiverse.cxf.annotation.CXFClient;
 
-@Application    // or any other CDI scope
+@ApplicationScoped    // or any other CDI scope
 public class MySoapClient {
 
     private boolean logging = ..  // depending on context, logging is on or off

--- a/docs/modules/ROOT/pages/handlers.adoc
+++ b/docs/modules/ROOT/pages/handlers.adoc
@@ -24,10 +24,10 @@ The `application.properties` can be configured as shown below.
 [source,properties]
 ----
 # A web service endpoint with multiple Handler classes
-quarkus.cxf.endpoint."/greeting-service".handlers=com.example.MySOAPHandler,com.example.AnotherSOAPHandler
+quarkus.cxf.endpoint."/greeting-service".handlers=org.acme.MySOAPHandler,org.acme.AnotherSOAPHandler
 
 # A web service client with a single Handler
-quarkus.cxf.client."/greeting-client".in-interceptors=com.example.MySOAPHandler
+quarkus.cxf.client."/greeting-client".in-interceptors=org.acme.MySOAPHandler
 ----
 
 Please note that `Handler` classes will be attempted to be loaded via CDI first, and if no CDI beans are available, then the constructor with no parameters will be invoked to instantiate each class.

--- a/docs/modules/ROOT/pages/interceptors-and-features.adoc
+++ b/docs/modules/ROOT/pages/interceptors-and-features.adoc
@@ -10,10 +10,10 @@ Annotations can be used on either the service interface or implementor classes.
 [source,java]
 ----
 @org.apache.cxf.feature.Features (features = {"org.apache.cxf.feature.LoggingFeature"})
-@org.apache.cxf.interceptor.InInterceptors (interceptors = {"com.example.Test1Interceptor" })
-@org.apache.cxf.interceptor.InFaultInterceptors (interceptors = {"com.example.Test2Interceptor" })
-@org.apache.cxf.interceptor.OutInterceptors (interceptors = {"com.example.Test1Interceptor" })
-@org.apache.cxf.interceptor.InFaultInterceptors (interceptors = {"com.example.Test2Interceptor","com.example.Test3Intercetpor" })
+@org.apache.cxf.interceptor.InInterceptors (interceptors = {"org.acme.Test1Interceptor" })
+@org.apache.cxf.interceptor.InFaultInterceptors (interceptors = {"org.acme.Test2Interceptor" })
+@org.apache.cxf.interceptor.OutInterceptors (interceptors = {"org.acme.Test1Interceptor" })
+@org.apache.cxf.interceptor.InFaultInterceptors (interceptors = {"org.acme.Test2Interceptor","org.acme.Test3Intercetpor" })
 @WebService(endpointInterface = "org.apache.cxf.javascript.fortest.SimpleDocLitBare",
             targetNamespace = "uri:org.apache.cxf.javascript.fortest")
 public class SayHiImplementation implements SayHi {
@@ -31,9 +31,9 @@ Both feature and interceptor classes will be attempted to be loaded via CDI firs
 [source,properties]
 ----
 quarkus.cxf.endpoint."/greeting".features=org.apache.cxf.feature.LoggingFeature
-quarkus.cxf.endpoint."/greeting".in-interceptors=com.example.MyInterceptor
-quarkus.cxf.endpoint."/greeting".out-interceptors=com.example.MyInterceptor
-quarkus.cxf.endpoint."/greeting".in-fault-interceptors=com.example.MyInterceptor
-quarkus.cxf.endpoint."/greeting".out-fault-interceptors=com.example.MyInterceptor
+quarkus.cxf.endpoint."/greeting".in-interceptors=org.acme.MyInterceptor
+quarkus.cxf.endpoint."/greeting".out-interceptors=org.acme.MyInterceptor
+quarkus.cxf.endpoint."/greeting".in-fault-interceptors=org.acme.MyInterceptor
+quarkus.cxf.endpoint."/greeting".out-fault-interceptors=org.acme.MyInterceptor
 ----
 

--- a/docs/modules/ROOT/pages/providers.adoc
+++ b/docs/modules/ROOT/pages/providers.adoc
@@ -39,7 +39,7 @@ The `application.properties` can be configured as shown below.
 [source,properties]
 ----
 # A web service endpoint with the Provider implementation class
-quarkus.cxf.endpoint."/stream-source".implementor=com.example.StreamSourcePayloadProvider
+quarkus.cxf.endpoint."/stream-source".implementor=org.acme.StreamSourcePayloadProvider
 ----
 
 Please note that `Provider` classes will be attempted to be loaded via CDI first, and if no CDI beans are available, then the constructor with no parameters will be invoked to instantiate each class.


### PR DESCRIPTION
Replaced 'com.example' references with 'org.acme'