### PR TITLE
Set Quarkus 2.10.2.Final in docs

### DIFF
--- a/docs/modules/ROOT/pages/attributes.adoc
+++ b/docs/modules/ROOT/pages/attributes.adoc
@@ -1,2 +1,2 @@
-:quarkus-version: 2.10.0.Final
+:quarkus-version: 2.10.2.Final
 :quarkus-cxf-version: 1.2.0


### PR DESCRIPTION
I can't say I'm familiar with how exactly docs are generated/built, but I kept getting this change locally, so I suppose this was forgotten somehow.