### PR TITLE
DestinationRegistry is now static

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/cxf/transport/CxfHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/cxf/transport/CxfHandler.java
@@ -24,7 +24,6 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.transport.ConduitInitiatorManager;
 import org.apache.cxf.transport.DestinationFactoryManager;
 import org.apache.cxf.transport.http.DestinationRegistry;
-import org.apache.cxf.transport.http.DestinationRegistryImpl;
 import org.apache.cxf.transport.servlet.ServletController;
 import org.apache.cxf.transport.servlet.servicelist.ServiceListGeneratorServlet;
 import org.jboss.logging.Logger;
@@ -82,7 +81,7 @@ public class CxfHandler implements Handler<RoutingContext> {
 
         LOGGER.trace("load destination");
         DestinationFactoryManager dfm = this.bus.getExtension(DestinationFactoryManager.class);
-        destinationRegistry = new DestinationRegistryImpl();
+        destinationRegistry = VertxDestinationRegistryFactory.getDestinationRegistry();
         VertxDestinationFactory destinationFactory = new VertxDestinationFactory(destinationRegistry);
         dfm.registerDestinationFactory("http://cxf.apache.org/transports/quarkus", destinationFactory);
         ConduitInitiatorManager extension = bus.getExtension(ConduitInitiatorManager.class);

--- a/core/runtime/src/main/java/io/quarkiverse/cxf/transport/VertxDestinationFactory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/cxf/transport/VertxDestinationFactory.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.cxf.transport;
 
+import static java.lang.String.format;
+
 import java.io.IOException;
 
 import org.apache.cxf.Bus;
@@ -9,10 +11,16 @@ import org.apache.cxf.transport.Destination;
 import org.apache.cxf.transport.DestinationFactory;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.apache.cxf.transport.http.DestinationRegistry;
+import org.jboss.logging.Logger;
 
 public class VertxDestinationFactory extends SoapTransportFactory implements DestinationFactory {
+    private static final Logger LOGGER = Logger.getLogger(VertxDestinationFactory.class);
 
     protected final DestinationRegistry registry;
+
+    public VertxDestinationFactory() {
+        this(VertxDestinationRegistryFactory.getDestinationRegistry());
+    }
 
     protected VertxDestinationFactory(DestinationRegistry registry) {
         super();
@@ -25,12 +33,16 @@ public class VertxDestinationFactory extends SoapTransportFactory implements Des
             throw new IllegalArgumentException("EndpointInfo cannot be null");
         }
         synchronized (registry) {
+            String endpointAddress = endpointInfo.getAddress();
+            LOGGER.debug(format("Looking for destination for address %s...", endpointAddress));
             AbstractHTTPDestination d = registry.getDestinationForPath(endpointInfo.getAddress());
             if (d == null) {
+                LOGGER.debug(format("Creating VertxDestination for address %s...", endpointAddress));
                 d = new VertxDestination(endpointInfo, bus, registry);
                 registry.addDestination(d);
                 d.finalizeConfig();
             }
+            LOGGER.debug(format("Destination for address %s is %s", endpointAddress, d));
             return d;
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/cxf/transport/VertxDestinationRegistryFactory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/cxf/transport/VertxDestinationRegistryFactory.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.cxf.transport;
+
+import org.apache.cxf.transport.http.DestinationRegistry;
+import org.apache.cxf.transport.http.DestinationRegistryImpl;
+
+public class VertxDestinationRegistryFactory {
+    public static DestinationRegistry INSTANCE = new DestinationRegistryImpl();
+
+    public static DestinationRegistry getDestinationRegistry() {
+        return INSTANCE;
+    }
+}


### PR DESCRIPTION
In order to be able to expose Camel route as CXF service, the destination registry must be visible to both Camel CXF and Quarkus CXF. By making it a single instance, we can achieve it and still register all destinations as necessary.
