### PR TITLE
CxfClientTest.outInterceptor() gets a different body in native mode 

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -370,6 +370,9 @@
                                 <!-- whose dependencies we want to cover in the flattened BOM -->
                                 <resolutionEntryPointInclude>io.quarkiverse.cxf:*</resolutionEntryPointInclude>
                             </resolutionEntryPointIncludes>
+                            <requiredBomEntryIncludes>
+                                <requiredBomEntryInclude>org.apache.cxf</requiredBomEntryInclude>
+                            </requiredBomEntryIncludes>
                             <flattenedFullPomFile>${project.build.directory}/flattened-full-pom.xml</flattenedFullPomFile>
                             <flattenedReducedPomFile>${project.build.directory}/flattened-reduced-pom.xml</flattenedReducedPomFile>
                             <flattenedReducedVerbosePomFile>${project.build.directory}/flattened-reduced-verbose-pom.xml</flattenedReducedVerbosePomFile>

--- a/integration-tests/client/src/test/java/io/quarkiverse/cxf/client/it/CxfClientTest.java
+++ b/integration-tests/client/src/test/java/io/quarkiverse/cxf/client/it/CxfClientTest.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.cxf.client.it;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
@@ -71,9 +70,7 @@ public class CxfClientTest {
                 .get("/cxf/client/calculator/myFaultyCalculator/multiply")
                 .then()
                 .statusCode(500)
-                // Should be .body(is("No luck at this time, Luke!"));
-                // see https://github.com/quarkiverse/quarkus-cxf/issues/497
-                .body(containsString("No luck at this time, Luke!"));
+                .body(is("No luck at this time, Luke!"));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
         <supported-maven.versions>[3.6.2,)</supported-maven.versions>
 
-        <cq-maven-plugin.version>3.1.1</cq-maven-plugin.version>
+        <cq-maven-plugin.version>3.2.0</cq-maven-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-idea-plugin.version>2.2.1</maven-idea-plugin.version>


### PR DESCRIPTION
Fix #497

This just sets the proper assertion in the test. We seem to have fixed it by some other previous commit.
