### PR TITLE
Document that `LoggingFeature` producer method needs `Unremovable`

### DIFF
--- a/docs/modules/ROOT/pages/message-logging.adoc
+++ b/docs/modules/ROOT/pages/message-logging.adoc
@@ -20,6 +20,8 @@ As an example, you could create a `Producers` class which creates a pre-configur
 ----
 import org.apache.cxf.ext.logging.LoggingFeature;
 
+import io.quarkus.arc.Unremovable;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
@@ -31,6 +33,7 @@ class Producers {
 
     @Produces
     @ApplicationScoped
+    @Unremovable
     LoggingFeature loggingFeature() {
         LoggingFeature loggingFeature = new LoggingFeature();
         loggingFeature.addSensitiveElementNames(new HashSet<>(sensitiveElementNames));


### PR DESCRIPTION
It took me a moment to see the warning in the logs about my `LoggingFeature` being removed...