### PR TITLE
Update CXF to 3.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <!-- Compile dependency versions (keep sorted alphabetically) -->
         <!-- Items annotated with @sync can be updated by running mvn cq:sync-versions -N -->
         <assertj.version>3.23.1</assertj.version>
-        <cxf.version>3.5.3</cxf.version>
+        <cxf.version>3.5.5</cxf.version>
         <cxf.xjc-utils.version>3.3.2</cxf.xjc-utils.version><!-- @sync org.apache.cxf:cxf:${cxf.version} prop:cxf.xjc-utils.version -->
         <ehcache.version>3.10.8</ehcache.version>
         <jakarta.jws-api.version>2.1.0</jakarta.jws-api.version><!-- @sync org.apache.cxf:cxf-parent:${cxf.version} prop:cxf.jakarta.jwsapi.version -->


### PR DESCRIPTION
Relates to #654

We cannot wait to sort out our dependabot issues because we need to "fix" https://nvd.nist.gov/vuln/detail/CVE-2022-46364

[Release Notes 3.5.5](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310511&version=12352350)
[Release Notes 3.5.4](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310511&version=12351855)