### PR TITLE
Revert "Move ProdModeTests to isolated execution until RestAssured port reset is fixed upstream"

### DIFF
--- a/extensions/core/deployment/pom.xml
+++ b/extensions/core/deployment/pom.xml
@@ -104,47 +104,7 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <groups>!ProdModeTest</groups>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
-    <profiles>
-        <!-- Isolate QuarkusProdModeTests because of a RestAssured port reset issue (upstream problem).
-             This is in a profile to allow deactivation via "-P'!ProdModeTests'". -->
-        <profile>
-            <id>ProdModeTests</id>
-            <activation>
-                <!-- Basically active by default, but with the advantage over <activeByDefault>
-                     that "-P unrelated-profile"" will not deactivate this profile. -->
-                <property>
-                    <name>java.version</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>ProdModeTests</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <configuration>
-                                    <groups>ProdModeTest</groups>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/UberJarMergedResourcesTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/UberJarMergedResourcesTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.logging.LogRecord;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -14,12 +13,11 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-@Tag("ProdModeTest")
 public class UberJarMergedResourcesTest {
 
     @RegisterExtension
     static final QuarkusProdModeTest runner = new QuarkusProdModeTest()
-            .withApplicationRoot(jar -> jar
+            .withApplicationRoot((jar) -> jar
                     .addClass(UberJarMain.class))
             .setApplicationName("uber-jar")
             .setApplicationVersion("0.1-SNAPSHOT")


### PR DESCRIPTION
This reverts commit 002d812231a8e1d70bd10f3c50af89e89bd27343.

Not needed anymore after https://github.com/quarkusio/quarkus/pull/30389 (now that we have updated to Quarkus 2.16.0.Final).