### PR TITLE
Handle @sync dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,8 +11,36 @@
   ],
   "packageRules": [
     {
+      "description": "Ignore major updates for matched packages (allow only minor and patch updates)",
       "matchPackagePatterns": [
-        "io.quarkiverse.cxf", "org.glassfish.jaxb:jaxb-runtime"
+        "org.apache.cxf.xjc-utils:cxf-xjc-runtime",
+        "jakarta.mail:jakarta.mail-api",
+        "jakarta.jws:jakarta.jws-api",
+        "jakarta.xml.soap:jakarta.xml.soap-api",
+        "jakarta.xml.ws:jakarta.xml.ws-api",
+        "org.apache.neethi:neethi",
+        "com.sun.xml.messaging.saaj:saaj-impl",
+        "org.slf4j:slf4j-simple"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Ignore major and minor updates for matched packages (allow only patch updates)",
+      "matchPackagePatterns": [
+        "org.glassfish.jaxb:jaxb-runtime"
+      ],
+      "matchUpdateTypes": [
+        "major", "minor"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Ignore all updates for matched packages",
+      "matchPackagePatterns": [
+        "io.quarkiverse.cxf"
       ],
       "enabled": false
     }


### PR DESCRIPTION
@ppalaga cc: @famod Please review this PR, I was hoping to address the issues outlined in https://github.com/quarkiverse/quarkus-cxf/pull/739#issuecomment-1451920919

I believe most CVEs would typically come through as either a minor or patch release ... but wasn't sure what makes the most sense in terms of how I have grouped the dependencies in the PR.  Please share your thoughts.

If we need to add specific dependency version ranges, that can also easily be done using:
https://docs.renovatebot.com/configuration-options/#allowedversions