### PR TITLE
Address DTD lookups in network-restricted environments

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -1,12 +1,6 @@
 package io.quarkiverse.cxf.deployment;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -48,6 +42,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -207,9 +202,10 @@ class QuarkusCxfProcessor {
             XPath xpath = XPathFactory.newInstance().newXPath();
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "http");
+            documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
             DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+            builder.setEntityResolver(new NoOpEntityResolver());
 
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
             Enumeration<URL> urls = loader.getResources("META-INF/wsdl.plugin.xml");
@@ -480,6 +476,14 @@ class QuarkusCxfProcessor {
             CXFRecorder recorder,
             ShutdownContextBuildItem shutdownContext) {
         recorder.resetDestinationRegistry(shutdownContext);
+    }
+
+    private static final class NoOpEntityResolver implements EntityResolver {
+        @Override
+        public InputSource resolveEntity(String publicId, String systemId) {
+            LOGGER.info("Preventing access to " + systemId);
+            return new InputSource(new StringReader(""));
+        }
     }
 
     private static class QuarkusCapture implements GeneratedClassClassLoaderCapture {

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/UberJarMergedResourcesTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/UberJarMergedResourcesTest.java
@@ -39,6 +39,11 @@ public class UberJarMergedResourcesTest {
                 .filteredOn(r -> r.getMessage().contains("Building uber jar"))
                 .hasSize(1);
 
+        // Verify that external DTD calls are blocked (to prevent XML External Entity Injection attacks)
+        assertThat(buildLogRecords)
+                .filteredOn(r -> r.getMessage().contains("Preventing access to http://java.sun.com/dtd/properties.dtd"))
+                .hasSize(2);
+
         // Message will show up in the logs in case of any error that leads to a merge failure for wsdl.plugin.xml
         assertThat(buildLogRecords)
                 .filteredOn(r -> r.getMessage().contains("cannot merge wsdl.plugin.xml"))


### PR DESCRIPTION
This PR addresses #744 by disabling the DTD lookup for `http://java.sun.com/dtd/properties.dtd`

@ppalaga @famod Could you please review?