### PR TITLE
Revert e7cdfe9 Temporary workaround for 

### DIFF
--- a/docs/modules/ROOT/examples/calculator-client/application.properties
+++ b/docs/modules/ROOT/examples/calculator-client/application.properties
@@ -21,7 +21,3 @@ quarkus.cxf.client.codeFirstClient.service-interface=io.quarkiverse.cxf.client.i
 quarkus.cxf.client.codeFirstClient.endpoint-namespace=http://www.jboss.org/eap/quickstarts/wscalculator/Calculatorrr
 quarkus.cxf.client.codeFirstClient.endpoint-name=CalculatorService
 
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false
-

--- a/docs/modules/ROOT/examples/soap-service/application.properties
+++ b/docs/modules/ROOT/examples/soap-service/application.properties
@@ -54,8 +54,3 @@ quarkus.cxf.client."greeting".service-interface=io.quarkiverse.cxf.it.server.Gre
 #
 quarkus.cxf.client."greetingclient".client-endpoint-url=http://localhost:8081/soap/greeting
 quarkus.cxf.client."greetingclient".service-interface=io.quarkiverse.cxf.it.server.GreetingClientWebService
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false
-

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/NamedInterceptorBeanTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/NamedInterceptorBeanTest.java
@@ -25,10 +25,7 @@ public class NamedInterceptorBeanTest {
             .overrideConfigKey("quarkus.cxf.endpoint.\"/fruit\".implementor",
                     "io.quarkiverse.cxf.deployment.test.FruitWebServiceImpl")
             .overrideConfigKey("quarkus.cxf.endpoint.\"/fruit\".handlers", "#barDescriptionAppender,#fooDescriptionAppender")
-            .overrideConfigKey("quarkus.cxf.client.\"fruitClient\".client-endpoint-url", "http://localhost:8081/fruit")
-            // Workaround for https://github.com/quarkusio/quarkus/issues/31646
-            // Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-            .overrideConfigKey("quarkus.jaxb.validate-jaxb-context", "false");
+            .overrideConfigKey("quarkus.cxf.client.\"fruitClient\".client-endpoint-url", "http://localhost:8081/fruit");
 
     @Inject
     @CXFClient("fruitClient")

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/ServerDevModeTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/ServerDevModeTest.java
@@ -102,9 +102,6 @@ public class ServerDevModeTest {
         Properties props = new Properties();
         props.setProperty("quarkus.cxf.endpoint.\"/fruit\".implementor",
                 io.quarkiverse.cxf.deployment.test.FruitWebServiceImpl.class.getName());
-        // Workaround for https://github.com/quarkusio/quarkus/issues/31646
-        // Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-        props.setProperty("quarkus.jaxb.validate-jaxb-context", "false");
         try {
             props.store(writer, "");
         } catch (IOException e) {

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/UberJarMergedResourcesTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/UberJarMergedResourcesTest.java
@@ -24,9 +24,6 @@ public class UberJarMergedResourcesTest {
             .setRun(true)
             .setExpectExit(true)
             .overrideConfigKey("quarkus.package.type", "uber-jar")
-            // Workaround for https://github.com/quarkusio/quarkus/issues/31646
-            // Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-            .overrideConfigKey("quarkus.jaxb.validate-jaxb-context", "false")
             .setLogRecordPredicate(r -> "io.quarkiverse.cxf.deployment.QuarkusCxfProcessor".equals(r.getLoggerName()) ||
                     "io.quarkus.deployment.pkg.steps.JarResultBuildStep".equals(r.getLoggerName()));
 

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/WsdlLocationTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/WsdlLocationTest.java
@@ -40,10 +40,7 @@ public class WsdlLocationTest {
             .overrideConfigKey("quarkus.cxf.endpoint.\"/wsdllocation\".implementor",
                     HelloServiceImpl.class.getName())
             .overrideConfigKey("quarkus.cxf.endpoint.\"/wsdllocation-provider\".implementor",
-                    HelloProvider.class.getName())
-            // Workaround for https://github.com/quarkusio/quarkus/issues/31646
-            // Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-            .overrideConfigKey("quarkus.jaxb.validate-jaxb-context", "false");
+                    HelloProvider.class.getName());
 
     @Test
     @Disabled("https://github.com/quarkiverse/quarkus-cxf/issues/557")

--- a/extensions/core/deployment/src/test/resources/application-cxf-server-test.properties
+++ b/extensions/core/deployment/src/test/resources/application-cxf-server-test.properties
@@ -1,6 +1,2 @@
 quarkus.cxf.endpoint."/fruit".implementor=io.quarkiverse.cxf.deployment.test.FruitWebServiceImpl
 quarkus.cxf.endpoint."/fruit".published-endpoint-url=https://io.quarkus-cxf.com/fruit
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false

--- a/extensions/core/deployment/src/test/resources/application-cxf-test.properties
+++ b/extensions/core/deployment/src/test/resources/application-cxf-test.properties
@@ -5,11 +5,3 @@ quarkus.cxf.client."fruitclient".service-interface=io.quarkiverse.cxf.deployment
 
 quarkus.cxf.client."foo".client-endpoint-url=http://localhost:8081/fruit
 quarkus.cxf.client."foo".features=org.apache.cxf.feature.LoggingFeature
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false

--- a/extensions/features-logging/deployment/src/test/java/io/quarkiverse/cxf/features/logging/deployment/DefaultLoggingFeatureTest.java
+++ b/extensions/features-logging/deployment/src/test/java/io/quarkiverse/cxf/features/logging/deployment/DefaultLoggingFeatureTest.java
@@ -23,9 +23,6 @@ public class DefaultLoggingFeatureTest {
             .overrideConfigKey("quarkus.cxf.endpoint.\"/hello\".features", "org.apache.cxf.ext.logging.LoggingFeature")
             .overrideConfigKey("quarkus.cxf.client.hello.service-interface", HelloService.class.getName())
             .overrideConfigKey("quarkus.cxf.client.hello.client-endpoint-url", "http://localhost:8081/hello")
-            // Workaround for https://github.com/quarkusio/quarkus/issues/31646
-            // Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-            .overrideConfigKey("quarkus.jaxb.validate-jaxb-context", "false")
             .setLogRecordPredicate(logRecord -> logRecord.getLoggerName().contains("org.apache.cxf.services.HelloService.RE")) // REQ_IN or RESP_OUT
             .assertLogRecords(records -> assertThat(records)
                     .extracting(LogRecord::getMessage)

--- a/extensions/features-logging/deployment/src/test/java/io/quarkiverse/cxf/features/logging/deployment/NamedLoggingFeatureTest.java
+++ b/extensions/features-logging/deployment/src/test/java/io/quarkiverse/cxf/features/logging/deployment/NamedLoggingFeatureTest.java
@@ -25,9 +25,6 @@ public class NamedLoggingFeatureTest {
             .overrideConfigKey("quarkus.cxf.endpoint.\"/hello\".features", "#namedLoggingFeature")
             .overrideConfigKey("quarkus.cxf.client.hello.service-interface", HelloService.class.getName())
             .overrideConfigKey("quarkus.cxf.client.hello.client-endpoint-url", "http://localhost:8081/hello")
-            // Workaround for https://github.com/quarkusio/quarkus/issues/31646
-            // Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-            .overrideConfigKey("quarkus.jaxb.validate-jaxb-context", "false")
             .setLogRecordPredicate(logRecord -> logRecord.getLoggerName().contains("org.apache.cxf.services.HelloService.RE")) // REQ_IN or RESP_OUT
             .assertLogRecords(records -> assertThat(records)
                     .extracting(LogRecord::getMessage)

--- a/extensions/features-logging/deployment/src/test/java/io/quarkiverse/cxf/features/logging/deployment/UnnamedLoggingFeatureTest.java
+++ b/extensions/features-logging/deployment/src/test/java/io/quarkiverse/cxf/features/logging/deployment/UnnamedLoggingFeatureTest.java
@@ -25,9 +25,6 @@ public class UnnamedLoggingFeatureTest {
             .overrideConfigKey("quarkus.cxf.endpoint.\"/hello\".features", "org.apache.cxf.ext.logging.LoggingFeature")
             .overrideConfigKey("quarkus.cxf.client.hello.service-interface", HelloService.class.getName())
             .overrideConfigKey("quarkus.cxf.client.hello.client-endpoint-url", "http://localhost:8081/hello")
-            // Workaround for https://github.com/quarkusio/quarkus/issues/31646
-            // Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-            .overrideConfigKey("quarkus.jaxb.validate-jaxb-context", "false")
             .setLogRecordPredicate(logRecord -> logRecord.getLoggerName().contains("org.apache.cxf.services.HelloService.RE")) // REQ_IN or RESP_OUT
             .assertLogRecords(records -> assertThat(records)
                     .extracting(LogRecord::getMessage)

--- a/integration-tests/client/src/main/resources/application.properties
+++ b/integration-tests/client/src/main/resources/application.properties
@@ -21,7 +21,3 @@ quarkus.cxf.client.codeFirstClient.service-interface=io.quarkiverse.cxf.client.i
 quarkus.cxf.client.codeFirstClient.endpoint-namespace=http://www.jboss.org/eap/quickstarts/wscalculator/Calculatorrr
 quarkus.cxf.client.codeFirstClient.endpoint-name=CalculatorService
 
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false
-

--- a/integration-tests/logging/src/main/resources/application.properties
+++ b/integration-tests/logging/src/main/resources/application.properties
@@ -10,8 +10,4 @@ quarkus.cxf.client."logging-client".endpoint-namespace=http://www.jboss.org/eap/
 quarkus.cxf.client."logging-client".endpoint-name=Calculator
 quarkus.cxf.client."logging-client".features=org.apache.cxf.ext.logging.LoggingFeature
 
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false
-
 quarkus.cxf.codegen.wsdl2java.includes = wsdl/CalculatorService.wsdl

--- a/integration-tests/mtom-awt/src/main/resources/application.properties
+++ b/integration-tests/mtom-awt/src/main/resources/application.properties
@@ -7,7 +7,3 @@ quarkus.cxf.client.imageServiceClient.client-endpoint-url=http://localhost:${qua
 quarkus.cxf.client.imageServiceClient.service-interface=io.quarkiverse.cxf.it.ws.mtom.awt.server.ImageService
 quarkus.cxf.client.imageServiceClient.endpoint-namespace="https://quarkiverse.github.io/quarkiverse-docs/quarkus-cxf/test/mtom-awt"
 quarkus.cxf.client.imageServiceClient.endpoint-name=ImageService
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false

--- a/integration-tests/mtom/src/main/resources/application.properties
+++ b/integration-tests/mtom/src/main/resources/application.properties
@@ -3,7 +3,3 @@ quarkus.cxf.endpoint."/mtom".features=org.apache.cxf.ext.logging.LoggingFeature
 quarkus.cxf.endpoint."/mtom".handlers=io.quarkiverse.cxf.it.ws.mtom.server.MtomEnforcer
 
 quarkus.native.resources.includes=*.properties,*.jks,*.wsdl,*.xml
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false

--- a/integration-tests/server/src/main/resources/application.properties
+++ b/integration-tests/server/src/main/resources/application.properties
@@ -54,8 +54,3 @@ quarkus.cxf.client."greeting".service-interface=io.quarkiverse.cxf.it.server.Gre
 #
 quarkus.cxf.client."greetingclient".client-endpoint-url=http://localhost:8081/soap/greeting
 quarkus.cxf.client."greetingclient".service-interface=io.quarkiverse.cxf.it.server.GreetingClientWebService
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false
-

--- a/integration-tests/ws-addressing/src/main/resources/application.properties
+++ b/integration-tests/ws-addressing/src/main/resources/application.properties
@@ -5,7 +5,3 @@ quarkus.cxf.endpoint."/addressing-anonymous".implementor=io.quarkiverse.cxf.it.w
 quarkus.cxf.endpoint."/addressing-decoupled".implementor=io.quarkiverse.cxf.it.ws.addressing.server.decoupled.WsAddressingImpl
 
 quarkus.native.resources.includes=wsdl/*.wsdl
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false

--- a/integration-tests/ws-rm/src/main/resources/application.properties
+++ b/integration-tests/ws-rm/src/main/resources/application.properties
@@ -4,7 +4,3 @@ quarkus.cxf.endpoint."/wsrm".features=org.apache.cxf.ext.logging.LoggingFeature
 quarkus.datasource.db-kind = derby
 quarkus.datasource.jdbc.url=jdbc:derby://localhost:1527/memory:testDB;create=true
 quarkus.datasource.jdbc.max-size=8
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false

--- a/integration-tests/ws-security-client/src/main/resources/application.properties
+++ b/integration-tests/ws-security-client/src/main/resources/application.properties
@@ -5,8 +5,4 @@ quarkus.cxf.client."wss-client".endpoint-namespace=http://www.jboss.org/eap/quic
 quarkus.cxf.client."wss-client".endpoint-name=WssCalculator
 quarkus.cxf.client."wss-client".out-interceptors=org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor
 
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false
-
 quarkus.cxf.codegen.wsdl2java.includes = wsdl/dir/*.wsdl

--- a/integration-tests/ws-security-server/src/main/resources/application.properties
+++ b/integration-tests/ws-security-server/src/main/resources/application.properties
@@ -6,7 +6,3 @@ quarkus.cxf.endpoint."/rounder".in-interceptors=org.apache.cxf.ws.security.wss4j
 quarkus.cxf.endpoint."/security-policy-hello".implementor=io.quarkiverse.cxf.it.ws.securitypolicy.server.WssSecurityPolicyHelloServiceImpl
 
 quarkus.native.resources.includes=bob.properties,alice.properties,alice.jks,bob.jks,encrypt-sign-policy.xml
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false

--- a/integration-tests/ws-trust/src/main/resources/application.properties
+++ b/integration-tests/ws-trust/src/main/resources/application.properties
@@ -6,7 +6,3 @@ quarkus.cxf.endpoint."/jaxws-samples-wsse-policy-trust".implementor=io.quarkiver
 quarkus.cxf.endpoint."/jaxws-samples-wsse-policy-trust".features=org.apache.cxf.ext.logging.LoggingFeature
 
 quarkus.native.resources.includes=*.properties,*.jks,*.wsdl,*.xml
-
-# Workaround for https://github.com/quarkusio/quarkus/issues/31646
-# Should not be needed with the Quarkus release coming after 3.0.0.Alpha5
-quarkus.jaxb.validate-jaxb-context = false


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/issues/31646 IllegalAnnotationsException Two classes have the same XML type name thrown at build time by quarkus-jaxb