### PR TITLE
WiP Unmarshalling Error: unexpected element when invoking a service with

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusJaxWsServiceFactoryBean.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusJaxWsServiceFactoryBean.java
@@ -1,12 +1,46 @@
 package io.quarkiverse.cxf.deployment;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.apache.cxf.jaxws.support.JaxWsServiceFactoryBean;
+import org.apache.cxf.service.model.InterfaceInfo;
+import org.apache.cxf.service.model.MessageInfo;
+import org.apache.cxf.service.model.MessagePartInfo;
+import org.apache.cxf.service.model.OperationInfo;
+import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
 
 public class QuarkusJaxWsServiceFactoryBean extends JaxWsServiceFactoryBean {
-    public List<String> getWrappersClassNames() {
-        return getExtraClass().stream().map(Class::getCanonicalName).collect(Collectors.toList());
+    public Set<String> getWrappersClassNames() {
+        /*
+         * Because JaxWsServiceFactoryBean.wrapperClasses is not accessible, we have to simulate
+         * the way how it is assembled in
+         * org.apache.cxf.jaxws.WrapperClassGenerator.generate(JaxWsServiceFactoryBean, InterfaceInfo, boolean)
+         */
+        InterfaceInfo interfaceInfo = getService().getServiceInfos().get(0).getInterface();
+        Set<String> wrapperBeans = new LinkedHashSet<>();
+        for (OperationInfo opInfo : interfaceInfo.getOperations()) {
+            if (opInfo.isUnwrappedCapable()) {
+                Method method = (Method) opInfo.getProperty(ReflectionServiceFactoryBean.METHOD);
+                if (method == null) {
+                    continue;
+                }
+                {
+                    final MessagePartInfo inf = opInfo.getInput().getFirstMessagePart();
+                    if (inf.getTypeClass() != null) {
+                        wrapperBeans.add(inf.getTypeClass().getName());
+                    }
+                }
+                MessageInfo messageInfo = opInfo.getUnwrappedOperation().getOutput();
+                if (messageInfo != null) {
+                    final MessagePartInfo inf = opInfo.getOutput().getFirstMessagePart();
+                    if (inf.getTypeClass() != null) {
+                        wrapperBeans.add(inf.getTypeClass().getName());
+                    }
+                }
+            }
+        }
+        return wrapperBeans;
     }
 }

--- a/integration-tests/mtom-awt/src/test/java/io/quarkiverse/cxf/it/ws/mtom/awt/server/MtomAwtTest.java
+++ b/integration-tests/mtom-awt/src/test/java/io/quarkiverse/cxf/it/ws/mtom/awt/server/MtomAwtTest.java
@@ -25,7 +25,6 @@ class MtomAwtTest {
     }
 
     @Test
-    @Disabled("https://github.com/quarkiverse/quarkus-cxf/issues/582")
     public void uploadDownloadMtom() throws IOException {
         assertUploadDownload(ClientKey.imageServiceClient);
     }


### PR DESCRIPTION
multiple parameters without explicit wrapper 

This is an attempt to f.i.x #582. While the `Unmarshalling Error: unexpected element` goes away, the fix unfortunately causes another issue with unexpected namespace declaration on elements that pops up in nearly all other tests. So this PR is perhaps only useful to show what does not work. Any ideas to f.i.x #582 are welcome!