### PR TITLE
Support java2ws in Quarkus code generation phase #797

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-cxf.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-cxf.adoc
@@ -98,6 +98,115 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.enabled]]`link:#quarkus-cxf_quarkus.cxf.java2ws.enabled[quarkus.cxf.java2ws.enabled]`
+
+[.description]
+--
+If `true` `java2ws` wsdl generation is run whenever there are Java classes annotated with `jakarta.jws.WebService` selected via following properties; otherwise `java2ws` is not executed.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.include]]`link:#quarkus-cxf_quarkus.cxf.java2ws.include[quarkus.cxf.java2ws.include]`
+
+[.description]
+--
+A Java regular expression for selecting classes which should be processed with `java2wsdl` tool. Regular expression is used for matching fully qualified names of the classes. The glob syntax is specified in `java.util.regex.Pattern`. 
+Examples:  
+ - `.++*++` will match both classes `src/main/java/test/io/quarkiverse/cxf/deployment/java2ws/FruitWebService.java` and `src/main/java/test/io/quarkiverse/cxf/deployment/java2ws/GreeterService.java` under the current Maven or Gradle module 
+ - `.++*++Fruit.++*++` matches `src/main/java/test/io/quarkiverse/cxf/deployment/java2ws/FruitWebService.java` and not `src/main/java/test/io/quarkiverse/cxf/deployment/java2ws/GreeterService.java`  
+The default value for `quarkus.cxf.java2ws.include` is `.++*++` Named parameter sets, such as `quarkus.cxf.java2ws.my-name.include` have no default and not specifying any `include` value there will cause a build time error. 
+Make sure that the class sets selected by `quarkus.cxf.java2ws.includes` and `quarkus.cxf.java2ws.++[++whatever-name++]++.include` do not overlap. 
+The generated wsdls are *not* included in native image.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS_INCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS_INCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.exclude]]`link:#quarkus-cxf_quarkus.cxf.java2ws.exclude[quarkus.cxf.java2ws.exclude]`
+
+[.description]
+--
+A Java regular expression for selecting classes which should *not* be processed with `java2ws` tool. Same syntax as `include`.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS_EXCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS_EXCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.additional-params]]`link:#quarkus-cxf_quarkus.cxf.java2ws.additional-params[quarkus.cxf.java2ws.additional-params]`
+
+[.description]
+--
+A comma separated list of additional command line parameters that should be passed to CXF `java2ws` tool along with the files selected by `include` and `exclude`. Example: `-portname,12345`. Check link:https://cxf.apache.org/docs/java-to-wsdl.html[`java2ws` documentation] for all supported options.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS_ADDITIONAL_PARAMS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS_ADDITIONAL_PARAMS+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.output-dir]]`link:#quarkus-cxf_quarkus.cxf.java2ws.output-dir[quarkus.cxf.java2ws.output-dir]`
+
+[.description]
+--
+The directory in which the WSDL output files are placed. The paths are relative to the working directory of the current Maven or Gradle module. If not specified, path `target/classes/wsdl` for Maven and `build/classes/wsdl` is used by default.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS_OUTPUT_DIR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS_OUTPUT_DIR+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.wsdl-name-template]]`link:#quarkus-cxf_quarkus.cxf.java2ws.wsdl-name-template[quarkus.cxf.java2ws.wsdl-name-template]`
+
+[.description]
+--
+A template for the names of the generated WSDL files. 
+There are 2 placeholders, which could be used in the template  
+ - `&lt;CLASS_NAME&gt;` will be replaced by the class's simple name. 
+ - `&lt;FULLY_QUALIFIED_CLASS_NAME&gt;` will be replaced by the class's fully qualified name, where all occurrences of '.' are replaced with '_'.  
+The default value is `<CLASS_NAME>.wsdl` 
+Examples:  
+ - `&lt;CLASS_NAME&gt;.wsdl` - generated file from class `++*++.GreeterService` will be named `GreeterService.wsdl` 
+ - `&lt;FULLY_QUALIFIED_CLASS_NAME&gt;.xml` - generated file from class `my.package.GreeterService` will be named my_package_GreeterService.xml
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS_WSDL_NAME_TEMPLATE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS_WSDL_NAME_TEMPLATE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.codegen.wsdl2java.-named-parameter-sets-.includes]]`link:#quarkus-cxf_quarkus.cxf.codegen.wsdl2java.-named-parameter-sets-.includes[quarkus.cxf.codegen.wsdl2java."named-parameter-sets".includes]`
 
 [.description]
@@ -151,6 +260,99 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_CXF_CODEGEN_WSDL2JAVA__NAMED_PARAMETER_SETS__ADDITIONAL_PARAMS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.include]]`link:#quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.include[quarkus.cxf.java2ws."named-parameter-sets".include]`
+
+[.description]
+--
+A Java regular expression for selecting classes which should be processed with `java2wsdl` tool. Regular expression is used for matching fully qualified names of the classes. The glob syntax is specified in `java.util.regex.Pattern`. 
+Examples:  
+ - `.++*++` will match both classes `src/main/java/test/io/quarkiverse/cxf/deployment/java2ws/FruitWebService.java` and `src/main/java/test/io/quarkiverse/cxf/deployment/java2ws/GreeterService.java` under the current Maven or Gradle module 
+ - `.++*++Fruit.++*++` matches `src/main/java/test/io/quarkiverse/cxf/deployment/java2ws/FruitWebService.java` and not `src/main/java/test/io/quarkiverse/cxf/deployment/java2ws/GreeterService.java`  
+The default value for `quarkus.cxf.java2ws.include` is `.++*++` Named parameter sets, such as `quarkus.cxf.java2ws.my-name.include` have no default and not specifying any `include` value there will cause a build time error. 
+Make sure that the class sets selected by `quarkus.cxf.java2ws.includes` and `quarkus.cxf.java2ws.++[++whatever-name++]++.include` do not overlap. 
+The generated wsdls are *not* included in native image.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__INCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__INCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.exclude]]`link:#quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.exclude[quarkus.cxf.java2ws."named-parameter-sets".exclude]`
+
+[.description]
+--
+A Java regular expression for selecting classes which should *not* be processed with `java2ws` tool. Same syntax as `include`.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__EXCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__EXCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.additional-params]]`link:#quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.additional-params[quarkus.cxf.java2ws."named-parameter-sets".additional-params]`
+
+[.description]
+--
+A comma separated list of additional command line parameters that should be passed to CXF `java2ws` tool along with the files selected by `include` and `exclude`. Example: `-portname,12345`. Check link:https://cxf.apache.org/docs/java-to-wsdl.html[`java2ws` documentation] for all supported options.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__ADDITIONAL_PARAMS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__ADDITIONAL_PARAMS+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.output-dir]]`link:#quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.output-dir[quarkus.cxf.java2ws."named-parameter-sets".output-dir]`
+
+[.description]
+--
+The directory in which the WSDL output files are placed. The paths are relative to the working directory of the current Maven or Gradle module. If not specified, path `target/classes/wsdl` for Maven and `build/classes/wsdl` is used by default.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__OUTPUT_DIR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__OUTPUT_DIR+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.wsdl-name-template]]`link:#quarkus-cxf_quarkus.cxf.java2ws.-named-parameter-sets-.wsdl-name-template[quarkus.cxf.java2ws."named-parameter-sets".wsdl-name-template]`
+
+[.description]
+--
+A template for the names of the generated WSDL files. 
+There are 2 placeholders, which could be used in the template  
+ - `&lt;CLASS_NAME&gt;` will be replaced by the class's simple name. 
+ - `&lt;FULLY_QUALIFIED_CLASS_NAME&gt;` will be replaced by the class's fully qualified name, where all occurrences of '.' are replaced with '_'.  
+The default value is `<CLASS_NAME>.wsdl` 
+Examples:  
+ - `&lt;CLASS_NAME&gt;.wsdl` - generated file from class `++*++.GreeterService` will be named `GreeterService.wsdl` 
+ - `&lt;FULLY_QUALIFIED_CLASS_NAME&gt;.xml` - generated file from class `my.package.GreeterService` will be named my_package_GreeterService.xml
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__WSDL_NAME_TEMPLATE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_CXF_JAVA2WS__NAMED_PARAMETER_SETS__WSDL_NAME_TEMPLATE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/extensions/core/deployment/pom.xml
+++ b/extensions/core/deployment/pom.xml
@@ -44,6 +44,13 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
+<!--            todo required for the successful build, should not be necessary  -->
+            <exclusions>
+                <exclusion>
+                    <artifactId>vaadin-development-mode-detector</artifactId>
+                    <groupId>org.mvnpm.at.vaadin</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -78,6 +85,10 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-tools-java2ws</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/Java2WsdlProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/Java2WsdlProcessor.java
@@ -1,0 +1,194 @@
+package io.quarkiverse.cxf.deployment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import jakarta.jws.WebService;
+
+import org.apache.cxf.tools.java2ws.JavaToWS;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+
+class Java2WsdlProcessor {
+
+    private static final Logger log = Logger.getLogger(Java2WsdlProcessor.class);
+    public static final String JAVA2WSDL_CONFIG_KEY_PREFIX = "quarkus.cxf.codegen.java2wsdl";
+
+    @BuildStep
+    void java2wsdl(CxfBuildTimeConfig cxfBuildTimeConfig, CombinedIndexBuildItem combinedIndex,
+            OutputTargetBuildItem outputTargetBuildItem,
+            //todo if reflectiveClassBuildItem producer is not here, step is ignored because it doesn't produce anything
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+
+        String defaultOutputDir = outputTargetBuildItem.getOutputDirectory().resolve("classes").resolve("wsdl").toString();
+        IndexView index = combinedIndex.getIndex();
+
+        if (!cxfBuildTimeConfig.java2ws.enabled) {
+            log.info("Skipping " + this.getClass() + " invocation on user's request");
+            return;
+        }
+
+        String[] services = index.getAnnotations(DotName.createSimple(WebService.class.getName()))
+                .stream()
+                .map(AnnotationInstance::target)
+                .map(annotationTarget -> {
+                    if (annotationTarget.kind().equals(AnnotationTarget.Kind.CLASS)) {
+                        return annotationTarget.asClass();
+                    }
+                    return null;
+                })
+                .filter(ci -> ci != null)
+                .map(classInfo -> classInfo.name().toString())
+                .toArray(String[]::new);
+
+        final Map<String, String> processedClasses = new HashMap<>();
+        boolean result = false;
+        //        //root is applied only if there is no namedParameters or if it contains at least one property
+        if (cxfBuildTimeConfig.java2ws.namedParameterSets.isEmpty()) {
+            result |= java2wsdl(services, cxfBuildTimeConfig.java2ws.rootParameterSet,
+                    JAVA2WSDL_CONFIG_KEY_PREFIX, processedClasses, defaultOutputDir, true);
+        }
+
+        //named
+        final Set<String> names = cxfBuildTimeConfig.java2ws.namedParameterSets.keySet();
+        for (String name : names) {
+            CxfBuildTimeConfig.Java2WsParameterSet params = cxfBuildTimeConfig.java2ws.namedParameterSets.get(name);
+            result |= java2wsdl(services, params, JAVA2WSDL_CONFIG_KEY_PREFIX + "." + name, processedClasses, defaultOutputDir,
+                    false);
+        }
+
+        if (!result) {
+            log.warn("java2wsdl processed 0 classes");
+        }
+    }
+
+    static boolean java2wsdl(String[] serviceClasses, CxfBuildTimeConfig.Java2WsParameterSet params,
+            String prefix,
+            Map<String, String> processedClasses,
+            String defaultLOutputDir,
+            boolean useDefaultIncludes) {
+
+        return scan(serviceClasses,
+                params.include.orElse(useDefaultIncludes ? CxfBuildTimeConfig.Java2WsParameterSet.DEFAULT_INCLUDES : null),
+                params.exclude, prefix, processedClasses, (String serviceClass) -> {
+                    final Java2WsdlParams java2WsdlParams = new Java2WsdlParams(serviceClass,
+                            params.outputDir.orElse(defaultLOutputDir),
+                            params.additionalParams.orElse(Collections.emptyList()),
+                            params.wsdlNameTemplate.orElse(CxfBuildTimeConfig.Java2WsParameterSet.DEFAULT_WSDL_NAME_TEMPLATE));
+                    if (log.isInfoEnabled()) {
+                        log.info(java2WsdlParams.appendLog(new StringBuilder("Running wsdl2java")).toString());
+                    }
+                    try {
+                        new JavaToWS(java2WsdlParams.toParameterArray()).run();
+                    } catch (Exception e) {
+                        throw new RuntimeException(
+                                java2WsdlParams.appendLog(new StringBuilder("Could not run wsdl2Java")).toString(),
+                                e);
+                    }
+                });
+    }
+
+    static boolean scan(
+            String[] classes,
+            String includes,
+            Optional<String> excludes,
+            String prefix,
+            Map<String, String> processedClasses,
+            Consumer<String> serviceClassConsumer) {
+
+        final String selectors = "    " + prefix + ".includes = " + includes +
+                (excludes.isPresent()
+                        ? "\n    " + prefix + ".excludes = " + excludes.get()
+                        : "");
+
+        final Consumer<String> chainedConsumer = serviceClass -> {
+            final String oldSelectors = processedClasses.get(serviceClass);
+            if (oldSelectors != null) {
+                throw new IllegalStateException("Service class " + serviceClass + " was already selected by\n\n"
+                        + oldSelectors
+                        + "\n\nand therefore it cannot once again be selected by\n\n" + selectors
+                        + "\n\nPlease make sure that the individual include/exclude sets are mutually exclusive.");
+            }
+            processedClasses.put(serviceClass, selectors);
+            serviceClassConsumer.accept(serviceClass);
+        };
+
+        Pattern includePatter = Pattern.compile(includes, Pattern.CASE_INSENSITIVE);
+        Optional<Pattern> excludePatter = excludes.map(p -> Pattern.compile(p, Pattern.CASE_INSENSITIVE));
+
+        Arrays.stream(classes)
+                .filter(cl -> includePatter.matcher(cl).matches())
+                .filter(cl -> excludePatter.isEmpty() || !excludePatter.get().matcher(cl).matches())
+                .forEach(chainedConsumer::accept);
+
+        return !processedClasses.isEmpty();
+    }
+
+    static class Java2WsdlParams {
+        private final String inputClass;
+        private final String outDir;
+        private final List<String> additionalParams;
+        private final String wsdlNameTemplate;
+
+        Java2WsdlParams(String inputClass, String outDir, List<String> additionalParams, String wsdlNameTemplate) {
+            super();
+            this.inputClass = inputClass;
+            this.outDir = outDir;
+            this.additionalParams = additionalParams;
+            this.wsdlNameTemplate = wsdlNameTemplate;
+        }
+
+        StringBuilder appendLog(StringBuilder sb) {
+            render(value -> sb.append(' ').append(value));
+            return sb;
+        }
+
+        String[] toParameterArray() {
+            final String[] result = new String[additionalParams.size() + 6];
+            final AtomicInteger i = new AtomicInteger(0);
+            render(value -> result[i.getAndIncrement()] = value);
+            return result;
+        }
+
+        void render(Consumer<String> paramConsumer) {
+            paramConsumer.accept("-wsdl");
+            paramConsumer.accept("-o");
+            paramConsumer.accept(generateWsdlName());
+            paramConsumer.accept("-d");
+            paramConsumer.accept(outDir.toString());
+            additionalParams.forEach(paramConsumer);
+            paramConsumer.accept(inputClass);
+        }
+
+        String generateWsdlName() {
+            try {
+                return wsdlNameTemplate
+                        .replaceAll("<CLASS_NAME>", Class.forName(inputClass).getSimpleName())
+                        .replaceAll("<FULLY_QUALIFIED_CLASS_NAME>", Class.forName(inputClass).getName().replace('.', '_'));
+            } catch (ClassNotFoundException e) {
+                //can not happen,because class is loaded from the index
+                throw new RuntimeException(String.format("Class '%s' can not be found. Should not happen.", inputClass));
+            }
+
+        }
+
+    }
+
+}

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -598,8 +598,13 @@ class QuarkusCxfProcessor {
                 final String slashName = name.indexOf('/') >= 0 ? name : name.replace('.', '/');
                 classOutput.getSourceWriter(slashName);
                 LOGGER.infof("Generated class %s", dotName);
-                classOutput.write(slashName, bytes);
-                generatedClasses.add(dotName);
+                //todo quick fix
+                try {
+                    classOutput.write(slashName, bytes);
+                    generatedClasses.add(dotName);
+                } catch (Exception e) {
+                    LOGGER.debugf("Class %s can not be used - skipping", dotName);
+                }
             }
         }
 

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/Fruit.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/Fruit.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.util.Objects;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Fruit", propOrder = {
+        "name",
+        "description"
+})
+public class Fruit {
+
+    @XmlElement
+    private String name;
+
+    @XmlElement
+    private String description;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Fruit)) {
+            return false;
+        }
+
+        Fruit other = (Fruit) obj;
+
+        return Objects.equals(other.getName(), this.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getName());
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/FruitWebService.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/FruitWebService.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebParam;
+import jakarta.jws.WebResult;
+import jakarta.jws.WebService;
+import jakarta.xml.ws.RequestWrapper;
+
+@WebService
+public interface FruitWebService {
+
+    @WebMethod
+    @WebResult(name = "countFruitsResponse", targetNamespace = "http://test.deployment.cxf.quarkiverse.io/", partName = "parameters")
+    int count();
+
+    @WebMethod
+    @RequestWrapper(localName = "add", targetNamespace = "http://test.deployment.cxf.quarkiverse.io/", className = "io.quarkiverse.cxf.deployment.test.Add")
+    void add(@WebParam(name = "fruit") Fruit fruit);
+
+    @WebMethod
+    @RequestWrapper(localName = "delete", targetNamespace = "http://test.deployment.cxf.quarkiverse.io/", className = "io.quarkiverse.cxf.deployment.test.Delete")
+    void delete(@WebParam(name = "deletedfruit") Fruit fruit);
+
+    @WebMethod
+    String getDescriptionByName(@WebParam(name = "name") String name);
+
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/GreeterService.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/GreeterService.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebService;
+
+@WebService
+public interface GreeterService {
+
+    @WebMethod
+    String greetMe(String name);
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlAdditionalParametersGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlAdditionalParametersGenTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlAdditionalParametersGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.java2ws.output-dir", "target/classes/wsdl/WsdlAdditionalParametersGenTest")
+            .overrideConfigKey("quarkus.cxf.java2ws.include", ".*")
+            .overrideConfigKey("quarkus.cxf.java2ws.additional-params", "-portname,12345,-h")
+            .setLogRecordPredicate(lr -> lr.getMessage().contains("-wsdl"))
+            .assertLogRecords(
+                    lrs -> {
+                        if (!lrs.stream()
+                                .anyMatch(logRecord -> logRecord.getMessage()
+                                        .contains("-h io.quarkiverse.cxf.deployment.java2ws.GreeterService"))) {
+                            Assertions.fail("There is no help message in the log.");
+                        }
+                    });
+
+    @Test
+    public void generationTest() throws IOException {
+        //tool will show help and will not generate wsdl
+        Assertions
+                .assertThat(Path.of("target/classes/wsdl/WsdlAdditionalParametersGenTest").resolve("GreeterService.wsdl")
+                        .toFile().exists())
+                .as("check Greeterservice.wsdl existence").isFalse();
+        Assertions
+                .assertThat(Path.of("target/classes/wsdl/WsdlAdditionalParametersGenTest").resolve("FruitWebService.wsdl")
+                        .toFile().exists())
+                .as("check FruitWebService.wsdl existence").isFalse();
+
+    }
+
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlConflictGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlConflictGenTest.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlConflictGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"group_01\".include", ".*")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"group_02\".include", ".*")
+            .setExpectedException(IllegalStateException.class);
+
+    @Test
+    public void generationTest() throws IOException {
+        Assertions.fail("Extension should not start");
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlDefaultConfGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlDefaultConfGenTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlDefaultConfGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .setLogRecordPredicate(lr -> lr.getMessage().contains("java2ws"));
+
+    @Test
+    public void generationTest() throws IOException {
+        Assertions
+                .assertThat(
+                        Path.of("target/classes/wsdl").resolve("GreeterService.wsdl").toFile().exists())
+                .as("check Greeterservice.wsdl existence").isTrue();
+        Assertions
+                .assertThat(
+                        Path.of("target/classes/wsdl").resolve("FruitWebService.wsdl").toFile().exists())
+                .as("check FruitWebService.wsdl existence").isTrue();
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlDisabledGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlDisabledGenTest.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlDisabledGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.output-dir", "target/classes/wsdl/WsdlDisabledGenTest")
+            .setLogRecordPredicate(lr -> lr.getMessage().contains("java2ws"))
+            .assertLogRecords(
+                    lrs -> {
+                        if (!lrs.isEmpty()) {
+                            Assertions.fail("There is java2ws execution.");
+                        }
+                    });
+
+    @Test
+    public void generationTest() throws IOException {
+        //asserting log
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlEmptyNamedIncludesGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlEmptyNamedIncludesGenTest.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlEmptyNamedIncludesGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"group_01\".output-dir",
+                    "target/classes/wsdl/WsdlEmptyNamedIncludesGenTest")
+            .setExpectedException(NullPointerException.class);
+
+    @Test
+    public void generationTest() throws IOException {
+        Assertions.fail("Extension should not start");
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlExcludesGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlExcludesGenTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlExcludesGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.java2ws.exclude", ".*FruitWebService")
+            .overrideConfigKey("quarkus.cxf.java2ws.output-dir", "target/classes/wsdl/WsdlExcludesGenTest");
+
+    @Test
+    public void generationTest() throws IOException {
+        Assertions
+                .assertThat(Path.of("target/classes/wsdl/WsdlExcludesGenTest").resolve("GreeterService.wsdl").toFile().exists())
+                .as("check Greeterservice.wsdl existence").isTrue();
+        Assertions
+                .assertThat(
+                        Path.of("target/classes/wsdl/WsdlExcludesGenTest").resolve("FruitWebService.wsdl").toFile().exists())
+                .as("check FruitWebService.wsdl existence").isFalse();
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlIncludesGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlIncludesGenTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlIncludesGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.java2ws.include", ".*Fruit.*")
+            .overrideConfigKey("quarkus.cxf.java2ws.output-dir", "target/classes/wsdl/WsdlIncludesGenTest");
+
+    @Test
+    public void generationTest() throws IOException {
+        Assertions
+                .assertThat(Path.of("target/classes/wsdl/WsdlIncludesGenTest").resolve("GreeterService.wsdl").toFile().exists())
+                .as("check Greeterservice.wsdl existence").isFalse();
+        Assertions
+                .assertThat(
+                        Path.of("target/classes/wsdl/WsdlIncludesGenTest").resolve("FruitWebService.wsdl").toFile().exists())
+                .as("check FruitWebService.wsdl existence").isTrue();
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlNamedGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlNamedGenTest.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlNamedGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.java2ws.include", ".*GreeterService")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"GS\".include", ".*GreeterService")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"GS\".output-dir", "target/classes/wsdl/WsdlNamedGenTest");
+
+    @Test
+    public void generationTest() throws IOException {
+        Assertions.assertThat(Path.of("target/classes/wsdl/WsdlNamedGenTest").resolve("GreeterService.wsdl").toFile().exists())
+                .as("check GreeterService.wsdl existence").isTrue();
+        Assertions.assertThat(Path.of("target/classes/wsdl/WsdlNamedGenTest").resolve("FruitWebService.wsdl").toFile().exists())
+                .as("check FruitWebService.wsdl existence").isFalse();
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlRootGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlRootGenTest.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlRootGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.java2ws.include", ".*")
+            .overrideConfigKey("quarkus.cxf.java2ws.output-dir", "target/classes/wsdl/WsdlRootGenTest");
+
+    @Test
+    public void generationTest() throws IOException {
+        Assertions.assertThat(Path.of("target/classes/wsdl/WsdlRootGenTest").resolve("GreeterService.wsdl").toFile().exists())
+                .as("check Greeterservice.wsdl existence").isTrue();
+        Assertions.assertThat(Path.of("target/classes/wsdl/WsdlRootGenTest").resolve("FruitWebService.wsdl").toFile().exists())
+                .as("check FruitWebService.wsdl existence").isTrue();
+    }
+}

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlTemplateNameGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/java2ws/WsdlTemplateNameGenTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.cxf.deployment.java2ws;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WsdlTemplateNameGenTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreeterService.class)
+                    .addClass(FruitWebService.class)
+                    .addClass(Fruit.class))
+            .overrideConfigKey("quarkus.cxf.codegen.wsdl2java.enabled", "false")
+            .overrideConfigKey("quarkus.cxf.java2ws.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"GS\".include", ".*GreeterService")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"GS\".output-dir", "target/classes/wsdl/WsdlTemplateNameGenTest")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"GS\".wsdl-name-template", "<CLASS_NAME>aaa<CLASS_NAME>.txt")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"FS\".include", ".*FruitWebService")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"FS\".output-dir", "target/classes/wsdl/WsdlTemplateNameGenTest")
+            .overrideConfigKey("quarkus.cxf.java2ws.\"FS\".wsdl-name-template", "test_<FULLY_QUALIFIED_CLASS_NAME>.wsdl");
+
+    @Test
+    public void generationTest() throws IOException {
+        Assertions
+                .assertThat(Path.of("target/classes/wsdl/WsdlTemplateNameGenTest")
+                        .resolve("GreeterServiceaaaGreeterService.txt").toFile().exists())
+                .as("check Greeterservice.wsdl existence").isTrue();
+        Assertions
+                .assertThat(Path.of("target/classes/wsdl/WsdlTemplateNameGenTest")
+                        .resolve("test_io_quarkiverse_cxf_deployment_java2ws_FruitWebService.wsdl").toFile().exists())
+                .as("check FruitWebService.wsdl existence").isTrue();
+    }
+}


### PR DESCRIPTION
fixes https://github.com/quarkiverse/quarkus-cxf/issues/797

There are 4 small problems, marked by `todo` in the comment of the code:
* there is a workaround in QuarkusCapture, which is not correct (eventhough it works, but may show possible problems)
* I had to keep `BuildProducer<ReflectiveClassBuildItem>` in `Java2WsdlProcessor.java2wsdl` to force Qiarkus to execute his build step. If producer  is not present, Quarkus ignores step because there is no output from it. I was not  able to find a proper solution for such scenario (I found `ArtifactResultBuildItem` which should be used, but item didn't work for me)
* java2ws feature is disabled by defaul. wsdl2java is enabled by default -> should behave probably in the same way
* exclusion of `vaadin-development-mode-detector:<groupId>org.mvnpm.at.vaadin` should not be necessary, but I can not build the module locally without it.