### PR TITLE
Remove the `**.wsdl` default for quarkus.cxf.codegen.wsdl2java.includes

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -70,6 +70,12 @@
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http-hc5</artifactId>
                 <version>${cxf.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -373,7 +379,7 @@
                             </requiredBomEntryIncludes>
                             <bannedDependencyResources>
                                 <bannedDependencyResource>
-                                    <location>classpath:enforcer-rules/quarkus-require-maven-version.xml</location>
+                                    <location>classpath:enforcer-rules/quarkus-banned-dependencies.xml</location>
                                 </bannedDependencyResource>
                                 <bannedDependencyResource>
                                     <location>${maven.multiModuleProjectDirectory}/src/build/enforcer-rules/quarkus-cxf-banned-dependencies.xml</location>
@@ -382,12 +388,6 @@
                                     <location>${maven.multiModuleProjectDirectory}/src/build/enforcer-rules/quarkus-cxf-banned-bom-dependencies.xml</location>
                                 </bannedDependencyResource>
                             </bannedDependencyResources>
-                            <bomEntryTransformations>
-                                <bomEntryTransformation>
-                                    <gavPattern>org.apache.camel:camel-opentelemetry</gavPattern>
-                                    <addExclusions>io.grpc:grpc-netty-shaded</addExclusions>
-                                </bomEntryTransformation>
-                            </bomEntryTransformations>
                             <flattenedFullPomFile>${project.build.directory}/flattened-full-pom.xml</flattenedFullPomFile>
                             <flattenedReducedPomFile>${project.build.directory}/flattened-reduced-pom.xml</flattenedReducedPomFile>
                             <flattenedReducedVerbosePomFile>${project.build.directory}/flattened-reduced-verbose-pom.xml</flattenedReducedVerbosePomFile>

--- a/docs/modules/ROOT/examples/calculator-client/application.properties
+++ b/docs/modules/ROOT/examples/calculator-client/application.properties
@@ -43,3 +43,5 @@ quarkus.cxf.client.clientWithRuntimeInitializedPayload.endpoint-namespace=http:/
 quarkus.cxf.client.clientWithRuntimeInitializedPayload.endpoint-name=CalculatorService
 quarkus.cxf.client.clientWithRuntimeInitializedPayload.native.runtime-initialized = true
 quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkiverse.cxf.client.it.rtinit.Operands\\,io.quarkiverse.cxf.client.it.rtinit.Result
+
+quarkus.cxf.codegen.wsdl2java.includes = wsdl/*.wsdl

--- a/docs/modules/ROOT/examples/calculator-client/application.properties
+++ b/docs/modules/ROOT/examples/calculator-client/application.properties
@@ -43,6 +43,3 @@ quarkus.cxf.client.clientWithRuntimeInitializedPayload.endpoint-namespace=http:/
 quarkus.cxf.client.clientWithRuntimeInitializedPayload.endpoint-name=CalculatorService
 quarkus.cxf.client.clientWithRuntimeInitializedPayload.native.runtime-initialized = true
 quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkiverse.cxf.client.it.rtinit.Operands\\,io.quarkiverse.cxf.client.it.rtinit.Result
-
-# Workaround https://github.com/quarkusio/quarkus/issues/32059
-quarkus.jaxb.exclude-classes = io.quarkiverse.cxf.client.it.rtinit.Operands,io.quarkiverse.cxf.client.it.rtinit.Result

--- a/docs/modules/ROOT/pages/includes/quarkus-cxf.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-cxf.adoc
@@ -49,10 +49,17 @@ a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.codegen.wsdl2ja
 A comma separated list of glob patterns for selecting WSDL files which should be processed with `wsdl2java` tool. The paths are relative to `src/main/resources` or `src/test/resources` directories of the current Maven or Gradle module. The glob syntax is specified in `io.quarkus.util.GlobUtil`. 
 Examples:  
  - `calculator.wsdl,fruits.wsdl` will match `src/main/resources/calculator.wsdl` and `src/main/resources/fruits.wsdl` under the current Maven or Gradle module, but will not match anything like `src/main/resources/subdir/calculator.wsdl` 
- - `my-++*++-service.wsdl` match `src/main/resources/my-foo-service.wsdl` and `src/main/resources/my-bar-service.wsdl` 
- - `++**++.wsdl` will match any of the above  Note that file extensions other than `.wsdl` will work during normal builds, but changes in the matching files may get overseen in Quarkus dev mode. Always using the `.wsdl` extension is thus recommended. 
-The default value for `quarkus.cxf.codegen.wsdl2java.includes` is `++**++.wsdl` Named parameter sets, such as `quarkus.cxf.codegen.wsdl2java.my-name.includes` have no default and not specifying any `includes` value there will cause a build time error. 
-Make sure that the file sets selected by `quarkus.cxf.codegen.wsdl2java.includes` and `quarkus.cxf.codegen.wsdl2java.++[++whatever-name++]++.includes` do not overlap. 
+ - `my-++*++-service.wsdl` will match `src/main/resources/my-foo-service.wsdl` and `src/main/resources/my-bar-service.wsdl` 
+ - `++**++.wsdl` will match any of the above  There is a separate `wsdl2java` execution for each of the matching WSDL files. If you need different `additional-params` for each WSDL file, you may want to define a separate named parameter set for each one of them. Here is an example: `++#++ Parameters for foo.wsdl
+quarkus.cxf.codegen.wsdl2java.foo-params.includes = wsdl/foo.wsdl
+quarkus.cxf.codegen.wsdl2java.foo-params.additional-params = -wsdlLocation,wsdl/foo.wsdl
+++#++ Parameters for bar.wsdl
+quarkus.cxf.codegen.wsdl2java.bar-params.includes = wsdl/bar.wsdl
+quarkus.cxf.codegen.wsdl2java.bar-params.additional-params = -wsdlLocation,wsdl/bar.wsdl,-xjc-Xts` 
+Note that file extensions other than `.wsdl` will work during normal builds, but changes in the matching files may get overseen in Quarkus dev mode. Always using the `.wsdl` extension is thus recommended. 
+There is no default value for this option, so `wsdl2java` code generation is disabled by default. 
+Specifying `quarkus.cxf.codegen.wsdl2java.my-name.excludes` without setting any `includes` will cause a build time error. 
+Make sure that the file sets selected by `quarkus.cxf.codegen.wsdl2java.includes` and `quarkus.cxf.codegen.wsdl2java.++[++whatever-name++]++.includes` do not overlap. Otherwise a build time exception will be thrown. 
 The files from `src/main/resources` selected by `includes` and `excludes` are automatically included in native image and therefore you do not need to include them via `quarkus.cxf.wsdl-path` (deprecated) or `quarkus.cxf.codegen.wsdl2java.includes/excludes`.
 
 ifdef::add-copy-button-to-env-var[]
@@ -105,10 +112,17 @@ a|icon:lock[title=Fixed at build time] [[quarkus-cxf_quarkus.cxf.codegen.wsdl2ja
 A comma separated list of glob patterns for selecting WSDL files which should be processed with `wsdl2java` tool. The paths are relative to `src/main/resources` or `src/test/resources` directories of the current Maven or Gradle module. The glob syntax is specified in `io.quarkus.util.GlobUtil`. 
 Examples:  
  - `calculator.wsdl,fruits.wsdl` will match `src/main/resources/calculator.wsdl` and `src/main/resources/fruits.wsdl` under the current Maven or Gradle module, but will not match anything like `src/main/resources/subdir/calculator.wsdl` 
- - `my-++*++-service.wsdl` match `src/main/resources/my-foo-service.wsdl` and `src/main/resources/my-bar-service.wsdl` 
- - `++**++.wsdl` will match any of the above  Note that file extensions other than `.wsdl` will work during normal builds, but changes in the matching files may get overseen in Quarkus dev mode. Always using the `.wsdl` extension is thus recommended. 
-The default value for `quarkus.cxf.codegen.wsdl2java.includes` is `++**++.wsdl` Named parameter sets, such as `quarkus.cxf.codegen.wsdl2java.my-name.includes` have no default and not specifying any `includes` value there will cause a build time error. 
-Make sure that the file sets selected by `quarkus.cxf.codegen.wsdl2java.includes` and `quarkus.cxf.codegen.wsdl2java.++[++whatever-name++]++.includes` do not overlap. 
+ - `my-++*++-service.wsdl` will match `src/main/resources/my-foo-service.wsdl` and `src/main/resources/my-bar-service.wsdl` 
+ - `++**++.wsdl` will match any of the above  There is a separate `wsdl2java` execution for each of the matching WSDL files. If you need different `additional-params` for each WSDL file, you may want to define a separate named parameter set for each one of them. Here is an example: `++#++ Parameters for foo.wsdl
+quarkus.cxf.codegen.wsdl2java.foo-params.includes = wsdl/foo.wsdl
+quarkus.cxf.codegen.wsdl2java.foo-params.additional-params = -wsdlLocation,wsdl/foo.wsdl
+++#++ Parameters for bar.wsdl
+quarkus.cxf.codegen.wsdl2java.bar-params.includes = wsdl/bar.wsdl
+quarkus.cxf.codegen.wsdl2java.bar-params.additional-params = -wsdlLocation,wsdl/bar.wsdl,-xjc-Xts` 
+Note that file extensions other than `.wsdl` will work during normal builds, but changes in the matching files may get overseen in Quarkus dev mode. Always using the `.wsdl` extension is thus recommended. 
+There is no default value for this option, so `wsdl2java` code generation is disabled by default. 
+Specifying `quarkus.cxf.codegen.wsdl2java.my-name.excludes` without setting any `includes` will cause a build time error. 
+Make sure that the file sets selected by `quarkus.cxf.codegen.wsdl2java.includes` and `quarkus.cxf.codegen.wsdl2java.++[++whatever-name++]++.includes` do not overlap. Otherwise a build time exception will be thrown. 
 The files from `src/main/resources` selected by `includes` and `excludes` are automatically included in native image and therefore you do not need to include them via `quarkus.cxf.wsdl-path` (deprecated) or `quarkus.cxf.codegen.wsdl2java.includes/excludes`.
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/user-guide/first-soap-client.adoc
+++ b/docs/modules/ROOT/pages/user-guide/first-soap-client.adoc
@@ -126,31 +126,40 @@ include::example$calculator-client/pom.xml[tag=first-soap-client.adoc-quarkus-ma
 * For Gradle projects no additional configurarion of `io.quarkus` plugin is needed
 * Put your WSDL files under `src/main/resources` or `src/test/resources` or any subdirectory thereof.
 * Your WSDL file names must end with `.wsdl`
+* Set `quarkus.cxf.codegen.wsdl2java.includes`
+  xref:reference/configuration-properties.adoc#quarkus-cxf_quarkus.cxf.codegen.wsdl2java.includes[configuration property]
+  to a pattern matching the WSDL files you wish to process.
+  If you want to process all WSDL files under `src/main/resources/wsdl` or `src/test/resources/wsdl`, set it as follows:
++
+.pom.xml
+[source,properties]
+----
+quarkus.cxf.codegen.wsdl2java.includes = wsdl/*.wsdl
+----
 
 This will generate Java classes in `target/generated-sources/wsdl2java` or
 `target/generated-test-sources/wsdl2java` directory.
-There, they will be automatically picked by the compiler plugin.
+They will be automatically picked by the compiler plugin there.
 Hence we are free to refer to them from our application or test code.
 
 Note that `quarkus-cxf` code generation uses the https://cxf.apache.org/docs/wsdl-to-java.html[wsdl2Java] utility
-from CXF under the hood.
+from CXF under the hood. `wsdl2Java` is called separately for each WSDL file selected by `includes` and `excludes`.
 
 Passing custom parameters to `wsdl2java` is possible through
 xref:reference/configuration-properties.adoc#quarkus-cxf_quarkus.cxf.codegen.wsdl2java.additional-params[`quarkus.cxf.codegen.wsdl2java.additional-params`] configuration parameter.
 
-It is also possible to generate from multiple WSDL files using different `wsdl2java` parameters
-for each WSDL file using named parameter sets as follows:
+If you need different `additional-params` for each WSDL file, you may want to define a separate named parameter set for
+each one of them. Here is an example:
 
 .application.properties
 [source,properties]
 ----
-# the default nameless parameter set
-quarkus.cxf.codegen.wsdl2java.includes = wsdl/foo.wsdl
-quarkus.cxf.codegen.wsdl2java.additional-params = -wsdlLocation,wsdl/foo.wsdl
-
-# another parameter set bearing name "my-named-params"
-quarkus.cxf.codegen.wsdl2java.my-named-params.includes = wsdl/bar.wsdl
-quarkus.cxf.codegen.wsdl2java.my-named-params.additional-params = -wsdlLocation,wsdl/bar.wsdl
+# Parameters for foo.wsdl
+quarkus.cxf.codegen.wsdl2java.foo-params.includes = wsdl/foo.wsdl
+quarkus.cxf.codegen.wsdl2java.foo-params.additional-params = -wsdlLocation,wsdl/foo.wsdl
+# Parameters for bar.wsdl
+quarkus.cxf.codegen.wsdl2java.bar-params.includes = wsdl/bar.wsdl
+quarkus.cxf.codegen.wsdl2java.bar-params.additional-params = -wsdlLocation,wsdl/bar.wsdl,-xjc-Xts
 ----
 
 TIP: Add `io.quarkiverse.cxf:quarkus-cxf-xjc-plugins` dependency to your project to be able to use

--- a/docs/modules/ROOT/pages/user-guide/first-soap-client.adoc
+++ b/docs/modules/ROOT/pages/user-guide/first-soap-client.adoc
@@ -146,7 +146,8 @@ Note that `quarkus-cxf` code generation uses the https://cxf.apache.org/docs/wsd
 from CXF under the hood. `wsdl2Java` is called separately for each WSDL file selected by `includes` and `excludes`.
 
 Passing custom parameters to `wsdl2java` is possible through
-xref:reference/configuration-properties.adoc#quarkus-cxf_quarkus.cxf.codegen.wsdl2java.additional-params[`quarkus.cxf.codegen.wsdl2java.additional-params`] configuration parameter.
+xref:reference/configuration-properties.adoc#quarkus-cxf_quarkus.cxf.codegen.wsdl2java.additional-params[`quarkus.cxf.codegen.wsdl2java.additional-params`] 
+configuration parameter.
 
 If you need different `additional-params` for each WSDL file, you may want to define a separate named parameter set for
 each one of them. Here is an example:

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/CxfBuildTimeConfig.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/CxfBuildTimeConfig.java
@@ -73,7 +73,6 @@ public class CxfBuildTimeConfig {
 
     @ConfigGroup
     public static class Wsdl2JavaParameterSet {
-        public static final String DEFAULT_INCLUDES = "**.wsdl";
 
         /**
          * A comma separated list of glob patterns for selecting WSDL files which should be processed with
@@ -87,20 +86,35 @@ public class CxfBuildTimeConfig {
          * {@code src/main/resources/fruits.wsdl} under the current Maven or Gradle module, but will not match anything
          * like
          * {@code src/main/resources/subdir/calculator.wsdl}
-         * <li>{@code my-*-service.wsdl} match {@code src/main/resources/my-foo-service.wsdl} and
+         * <li>{@code my-*-service.wsdl} will match {@code src/main/resources/my-foo-service.wsdl} and
          * {@code src/main/resources/my-bar-service.wsdl}
          * <li>{@code **.wsdl} will match any of the above
          * </ul>
+         * There is a separate {@code wsdl2java} execution for each of the matching WSDL files. If you need different
+         * {@link #additionalParams} for each WSDL file, you may want to define a separate named parameter set for each
+         * one of them. Here is an example:
+         *
+         * <pre>{@code
+         * # Parameters for foo.wsdl
+         * quarkus.cxf.codegen.wsdl2java.foo-params.includes = wsdl/foo.wsdl
+         * quarkus.cxf.codegen.wsdl2java.foo-params.additional-params = -wsdlLocation,wsdl/foo.wsdl
+         * # Parameters for bar.wsdl
+         * quarkus.cxf.codegen.wsdl2java.bar-params.includes = wsdl/bar.wsdl
+         * quarkus.cxf.codegen.wsdl2java.bar-params.additional-params = -wsdlLocation,wsdl/bar.wsdl,-xjc-Xts
+         * }</pre>
+         * <p>
          * Note that file extensions other than {@code .wsdl} will work during normal builds, but changes in the
          * matching files may get overseen in Quarkus dev mode. Always using the {@code .wsdl} extension is thus
          * recommended.
          * <p>
-         * The default value for {@code quarkus.cxf.codegen.wsdl2java.includes} is <code>**.wsdl</code>
-         * Named parameter sets, such as {@code quarkus.cxf.codegen.wsdl2java.my-name.includes}
-         * have no default and not specifying any {@code includes} value there will cause a build time error.
+         * There is no default value for this option, so {@code wsdl2java} code generation is disabled by default.
+         * <p>
+         * Specifying {@code quarkus.cxf.codegen.wsdl2java.my-name.excludes} without setting any {@code includes}
+         * will cause a build time error.
          * <p>
          * Make sure that the file sets selected by {@code quarkus.cxf.codegen.wsdl2java.includes} and
-         * {@code quarkus.cxf.codegen.wsdl2java.[whatever-name].includes} do not overlap.
+         * {@code quarkus.cxf.codegen.wsdl2java.[whatever-name].includes} do not overlap. Otherwise a build time
+         * exception will be thrown.
          * <p>
          * The files from {@code src/main/resources} selected by {@code includes} and {@code excludes} are automatically
          * included in

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -122,7 +122,6 @@ class QuarkusCxfProcessor {
                     classesDir,
                     cxfBuildTimeConfig.codegen.wsdl2java.rootParameterSet,
                     Wsdl2JavaCodeGen.WSDL2JAVA_CONFIG_KEY_PREFIX,
-                    CxfBuildTimeConfig.Wsdl2JavaParameterSet.DEFAULT_INCLUDES,
                     wsdlResourcePaths::add);
 
             for (Entry<String, Wsdl2JavaParameterSet> en : cxfBuildTimeConfig.codegen.wsdl2java.namedParameterSets.entrySet()) {
@@ -130,7 +129,6 @@ class QuarkusCxfProcessor {
                         target.getOutputDirectory(),
                         en.getValue(),
                         Wsdl2JavaCodeGen.WSDL2JAVA_NAMED_CONFIG_KEY_PREFIX + en.getKey(),
-                        null,
                         wsdlResourcePaths::add);
             }
 
@@ -145,13 +143,11 @@ class QuarkusCxfProcessor {
             Path inputDir,
             Wsdl2JavaParameterSet params,
             String prefix,
-            String defaultIncludes,
             Consumer<String> resourcePathConsumer) {
         Wsdl2JavaCodeGen.scan(
                 inputDir,
                 params.includes.isPresent() ? params.includes
-                        : Optional.of(
-                                defaultIncludes == null ? Collections.emptyList() : Collections.singletonList(defaultIncludes)),
+                        : Optional.of(Collections.emptyList()),
                 params.excludes,
                 prefix,
                 new HashMap<>(),

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/codegen/Wsdl2JavaCodeGen.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/codegen/Wsdl2JavaCodeGen.java
@@ -72,8 +72,7 @@ public class Wsdl2JavaCodeGen implements CodeGenProvider {
         final Path outDir = context.outDir();
 
         final Function<String, Optional<List<String>>> configFunction = key -> config.getOptionalValues(key, String.class);
-        final Wsdl2JavaParameterSet rootParams = buildParameterSet(configFunction, WSDL2JAVA_CONFIG_KEY_PREFIX,
-                Wsdl2JavaParameterSet.DEFAULT_INCLUDES);
+        final Wsdl2JavaParameterSet rootParams = buildParameterSet(configFunction, WSDL2JAVA_CONFIG_KEY_PREFIX);
         final Map<String, String> processedFiles = new HashMap<>();
         boolean result = false;
         result |= wsdl2java(context.inputDir(), rootParams, outDir, WSDL2JAVA_CONFIG_KEY_PREFIX, processedFiles);
@@ -81,8 +80,7 @@ public class Wsdl2JavaCodeGen implements CodeGenProvider {
         final Set<String> names = findParamSetNames(config.getPropertyNames());
         for (String name : names) {
             final String prefix = WSDL2JAVA_NAMED_CONFIG_KEY_PREFIX + name;
-            final Wsdl2JavaParameterSet namedParams = buildParameterSet(configFunction,
-                    prefix, null);
+            final Wsdl2JavaParameterSet namedParams = buildParameterSet(configFunction, prefix);
             result |= wsdl2java(context.inputDir(), namedParams, outDir, prefix, processedFiles);
         }
 
@@ -181,19 +179,15 @@ public class Wsdl2JavaCodeGen implements CodeGenProvider {
      *
      * @param config an abstraction of {@link Config#getOptionalValues(String, Class)} for easier testing
      * @param prefix the prefix of configuration keys from which we build the resulting {@link Wsdl2JavaParameterSet}
-     * @param defaultIncludes use this if {@code prefix + ".includes"} is not available
      * @return a new {@link Wsdl2JavaParameterSet}
      */
-    static Wsdl2JavaParameterSet buildParameterSet(Function<String, Optional<List<String>>> config, String prefix,
-            String defaultIncludes) {
+    static Wsdl2JavaParameterSet buildParameterSet(Function<String, Optional<List<String>>> config, String prefix) {
         final Wsdl2JavaParameterSet result = new Wsdl2JavaParameterSet();
 
         final Optional<List<String>> maybeIncludes = config.apply(prefix + ".includes");
         final List<String> includes;
         if (maybeIncludes.isPresent()) {
             includes = maybeIncludes.get();
-        } else if (defaultIncludes != null) {
-            includes = List.of(defaultIncludes);
         } else {
             includes = null;
         }
@@ -206,7 +200,7 @@ public class Wsdl2JavaCodeGen implements CodeGenProvider {
                     + " any of " + prefix + ".excludes or " + prefix + ".additional-params");
         }
 
-        result.includes = Optional.of(includes);
+        result.includes = Optional.ofNullable(includes);
         result.excludes = excludes;
         result.additionalParams = additionalParams;
 

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/codegen/Wsdl2JavaCodeGenTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/codegen/Wsdl2JavaCodeGenTest.java
@@ -41,11 +41,9 @@ public class Wsdl2JavaCodeGenTest {
     void buildParameterSetNameLessDefaults() {
         final Wsdl2JavaParameterSet params = Wsdl2JavaCodeGen.buildParameterSet(
                 new Config(Map.of()),
-                Wsdl2JavaCodeGen.WSDL2JAVA_CONFIG_KEY_PREFIX,
-                Wsdl2JavaParameterSet.DEFAULT_INCLUDES);
+                Wsdl2JavaCodeGen.WSDL2JAVA_CONFIG_KEY_PREFIX);
 
-        Assertions.assertThat(params.includes).isPresent().get().asList()
-                .containsExactly(Wsdl2JavaParameterSet.DEFAULT_INCLUDES);
+        Assertions.assertThat(params.includes).isEmpty();
         Assertions.assertThat(params.excludes).isEmpty();
         Assertions.assertThat(params.additionalParams).isEmpty();
     }
@@ -54,13 +52,12 @@ public class Wsdl2JavaCodeGenTest {
     void buildParameterSetNameLess() {
         final Wsdl2JavaParameterSet params = Wsdl2JavaCodeGen.buildParameterSet(
                 new Config(Map.of(
+                        "quarkus.cxf.codegen.wsdl2java.includes", List.of("**.wsdl"),
                         "quarkus.cxf.codegen.wsdl2java.excludes", List.of("foo.wsdl"),
                         "quarkus.cxf.codegen.wsdl2java.additional-params", List.of("-foo", "bar"))),
-                Wsdl2JavaCodeGen.WSDL2JAVA_CONFIG_KEY_PREFIX,
-                Wsdl2JavaParameterSet.DEFAULT_INCLUDES);
+                Wsdl2JavaCodeGen.WSDL2JAVA_CONFIG_KEY_PREFIX);
 
-        Assertions.assertThat(params.includes).isPresent().get().asList()
-                .containsExactly(Wsdl2JavaParameterSet.DEFAULT_INCLUDES);
+        Assertions.assertThat(params.includes).isPresent().get().asList().containsExactly("**.wsdl");
         Assertions.assertThat(params.excludes).isPresent().get().asList().containsExactly("foo.wsdl");
         Assertions.assertThat(params.additionalParams).get().asList().containsExactly("-foo", "bar");
     }
@@ -74,8 +71,7 @@ public class Wsdl2JavaCodeGenTest {
                             new Config(Map.of(
                                     "quarkus.cxf.codegen.wsdl2java.my-name.excludes", List.of("foo.wsdl"),
                                     "quarkus.cxf.codegen.wsdl2java.my-name.additional-params", List.of("-foo", "bar"))),
-                            Wsdl2JavaCodeGen.WSDL2JAVA_NAMED_CONFIG_KEY_PREFIX + "my-name",
-                            null);
+                            Wsdl2JavaCodeGen.WSDL2JAVA_NAMED_CONFIG_KEY_PREFIX + "my-name");
                 });
     }
 
@@ -86,8 +82,7 @@ public class Wsdl2JavaCodeGenTest {
                         "quarkus.cxf.codegen.wsdl2java.my-name.includes", List.of("*.wsdl"),
                         "quarkus.cxf.codegen.wsdl2java.my-name.excludes", List.of("foo.wsdl"),
                         "quarkus.cxf.codegen.wsdl2java.my-name.additional-params", List.of("-foo", "bar"))),
-                Wsdl2JavaCodeGen.WSDL2JAVA_NAMED_CONFIG_KEY_PREFIX + "my-name",
-                null);
+                Wsdl2JavaCodeGen.WSDL2JAVA_NAMED_CONFIG_KEY_PREFIX + "my-name");
 
         Assertions.assertThat(params.includes).isPresent().get().asList()
                 .containsExactly("*.wsdl");
@@ -101,7 +96,7 @@ public class Wsdl2JavaCodeGenTest {
         final List<Path> foundFiles = new ArrayList<>();
         Wsdl2JavaCodeGen.scan(
                 tempDir,
-                Optional.of(List.of(Wsdl2JavaParameterSet.DEFAULT_INCLUDES)),
+                Optional.of(List.of("**.wsdl")),
                 Optional.empty(),
                 "",
                 new HashMap<>(),

--- a/integration-tests/client/src/main/resources/application.properties
+++ b/integration-tests/client/src/main/resources/application.properties
@@ -44,5 +44,3 @@ quarkus.cxf.client.clientWithRuntimeInitializedPayload.endpoint-name=CalculatorS
 quarkus.cxf.client.clientWithRuntimeInitializedPayload.native.runtime-initialized = true
 quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkiverse.cxf.client.it.rtinit.Operands\\,io.quarkiverse.cxf.client.it.rtinit.Result
 
-# Workaround https://github.com/quarkusio/quarkus/issues/32059
-quarkus.jaxb.exclude-classes = io.quarkiverse.cxf.client.it.rtinit.Operands,io.quarkiverse.cxf.client.it.rtinit.Result

--- a/integration-tests/client/src/main/resources/application.properties
+++ b/integration-tests/client/src/main/resources/application.properties
@@ -44,3 +44,4 @@ quarkus.cxf.client.clientWithRuntimeInitializedPayload.endpoint-name=CalculatorS
 quarkus.cxf.client.clientWithRuntimeInitializedPayload.native.runtime-initialized = true
 quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkiverse.cxf.client.it.rtinit.Operands\\,io.quarkiverse.cxf.client.it.rtinit.Result
 
+quarkus.cxf.codegen.wsdl2java.includes = wsdl/*.wsdl

--- a/integration-tests/wsdl2java/src/main/resources/application.properties
+++ b/integration-tests/wsdl2java/src/main/resources/application.properties
@@ -1,1 +1,2 @@
+quarkus.cxf.codegen.wsdl2java.includes = **.wsdl
 quarkus.cxf.codegen.wsdl2java.additional-params = -wsdlLocation,classpath:wsdl/CalculatorService.wsdl,-xjc-Xts

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,9 @@
                                     <location>classpath:enforcer-rules/quarkus-require-maven-version.xml</location>
                                 </externalRules>
                                 <externalRules>
+                                    <location>classpath:enforcer-rules/quarkus-banned-dependencies.xml</location>
+                                </externalRules>
+                                <externalRules>
                                     <location>${maven.multiModuleProjectDirectory}/src/build/enforcer-rules/quarkus-cxf-banned-dependencies.xml</location>
                                 </externalRules>
                             </rules>


### PR DESCRIPTION
I am in favor of removing the quarkus.cxf.codegen.wsdl2java.includes default after getting feedback from @famod, @llowinge and @JiriOndrusek. 
@famod mentioned somewhere that the default would typically conflict with whatever named parameter set defined by the end user via quarkus.cxf.codegen.wsdl2java.foo-params.includes unless she narrows quarkus.cxf.codegen.wsdl2java.includes.
@JiriOndrusek mnetioned that the default may cause funny things under some circumstances once we have also java2wsdl.
So I hope there is a general agreement that wsdl2java should not be enabled without end user specifying an include.
