### PR TITLE
Do not skip keytool maven plugin during releases, generate certs with…

### DIFF
--- a/integration-tests/ws-security-server/pom.xml
+++ b/integration-tests/ws-security-server/pom.xml
@@ -83,7 +83,7 @@
                 <artifactId>keytool-maven-plugin</artifactId>
                 <configuration>
                     <keypass>password</keypass>
-                    <validity>365</validity>
+                    <validity>3650</validity>
                     <keyalg>RSA</keyalg>
                     <storepass>password</storepass>
                     <skip>${keytool.skip}</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,6 @@
                 <enforcer.skip>true</enforcer.skip>
                 <formatter.skip>true</formatter.skip>
                 <impsort.skip>true</impsort.skip>
-                <keytool.skip>true</keytool.skip>
                 <skipTests>true</skipTests>
                 <quarkus.build.skip>true</quarkus.build.skip>
             </properties>


### PR DESCRIPTION
… validity 10 years so that the test jars work for long enough when run on the Platform