### PR TITLE
initialize CodahaleMetricsProvider at runtime

### DIFF
--- a/extensions/features-metrics/deployment/src/main/java/io/quarkiverse/cxf/metrics/deployment/QuarkusCxfMetricsProcessor.java
+++ b/extensions/features-metrics/deployment/src/main/java/io/quarkiverse/cxf/metrics/deployment/QuarkusCxfMetricsProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.cxf.metrics.deployment;
 
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.metrics.MetricsFeature;
@@ -19,6 +20,12 @@ public class QuarkusCxfMetricsProcessor {
                 MetricsFeature.class.getName(),
                 DelegatingFeature.class.getName(),
                 MetricsFeature.Portable.class.getName()).methods().build());
+    }
+
+    @BuildStep
+    void runtimeInitialize(BuildProducer<RuntimeInitializedClassBuildItem> producer) {
+        producer.produce(
+                new RuntimeInitializedClassBuildItem("org.apache.cxf.metrics.codahale.CodahaleMetricsProvider"));
     }
 
 }


### PR DESCRIPTION
Native-Image reports, that CodahaleMetricsProvider should be initialized at runtime.

`Error: Class initialization of org.apache.cxf.metrics.codahale.CodahaleMetricsProvider failed. This error is reported at image build time because class org.apache.cxf.metrics.codahale.CodahaleMetricsProvider is registered for linking at image build time by command line Use the option --initialize-at-run-time=org.apache.cxf.metrics.codahale.CodahaleMetricsProvider to explicitly request delayed initialization of this class.
`