### PR TITLE
Fix asciidoc warnings

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-cxf.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-cxf.adoc
@@ -604,22 +604,6 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-cxf_quarkus.cxf.client.-clients-.service-interface]]`link:#quarkus-cxf_quarkus.cxf.client.-clients-.service-interface[quarkus.cxf.client."clients".service-interface]`
-
-[.description]
---
-The client interface class
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_CLIENT__CLIENTS__SERVICE_INTERFACE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_CXF_CLIENT__CLIENTS__SERVICE_INTERFACE+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
 a| [[quarkus-cxf_quarkus.cxf.client.-clients-.endpoint-namespace]]`link:#quarkus-cxf_quarkus.cxf.client.-clients-.endpoint-namespace[quarkus.cxf.client."clients".endpoint-namespace]`
 
 [.description]
@@ -781,20 +765,5 @@ endif::add-copy-button-to-env-var[]
 --|list of string 
 |
 
-
-a| [[quarkus-cxf_quarkus.cxf.client.-clients-.alternative]]`link:#quarkus-cxf_quarkus.cxf.client.-clients-.alternative[quarkus.cxf.client."clients".alternative]`
-
-[.description]
---
-Indicates whether this is an alternative proxy client configuration. If true, then this configuration is ignored when configuring a client without annotation `@CXFClient`.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_CXF_CLIENT__CLIENTS__ALTERNATIVE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_CXF_CLIENT__CLIENTS__ALTERNATIVE+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
 
 |===


### PR DESCRIPTION
Proof of all warnings gone:
<img width="336" alt="image" src="https://github.com/quarkiverse/quarkus-cxf/assets/11942401/3c1216c8-7b24-4079-84ad-6268fa493c5f">

Proof of warnings before this PR:
<img width="1099" alt="image" src="https://github.com/quarkiverse/quarkus-cxf/assets/11942401/ad85103e-820c-4caa-8e12-834a97eaf086">

Note: I only fixed branch 1.5 because that was the only branch with WARN.