### PR TITLE
Revert "Workaround #695 Mandrel 22.3.0.1-Final-java17: Class io.quark…

### DIFF
--- a/integration-tests/server/src/main/resources/META-INF/native-image/io.quarkiverse.cxf/quarkus-cxf-integration-tests/reflect-config.json
+++ b/integration-tests/server/src/main/resources/META-INF/native-image/io.quarkiverse.cxf/quarkus-cxf-integration-tests/reflect-config.json
@@ -1,6 +1,0 @@
-[
-    {
-        "name": "io.quarkiverse.cxf.it.server.Fruit[]",
-        "unsafeAllocated": true
-    }
-]


### PR DESCRIPTION
…iverse.cxf.it.server.Fruit[] is instantiated reflectively but was never registered.Register the class by adding unsafeAllocated for the class in reflect-config.json"

It looks like the workaround is not needed anymore