### PR TITLE
No instances of com.sun.management.internal.OperatingSystemImpl allow ed with -Dquarkus.native.builder-image=registry-proxy.engineering.redhat.com/rh-osbs/quarkus-mandrel-23-rhel8:23.0

### DIFF
--- a/extensions/ws-security/deployment/src/main/java/io/quarkiverse/cxf/ws/security/deployment/EhcacheProcessor.java
+++ b/extensions/ws-security/deployment/src/main/java/io/quarkiverse/cxf/ws/security/deployment/EhcacheProcessor.java
@@ -116,6 +116,7 @@ public class EhcacheProcessor {
                 "org.ehcache.sizeof.impl.JvmInformation",
                 "org.ehcache.shadow.org.terracotta.utilities.io.Files",
                 "org.ehcache.shadow.org.terracotta.offheapstore.storage.portability.BooleanPortability",
+                "org.ehcache.shadow.org.terracotta.offheapstore.util.PhysicalMemory",
                 "org.ehcache.xml.XmlConfiguration",
                 "org.ehcache.xml.ResourceConfigurationParser")
                 .map(RuntimeInitializedClassBuildItem::new)


### PR DESCRIPTION
 fix #982