### PR TITLE
Disable GH actions upgrades by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,3 @@ updates:
     # Prevent PRs from opening except for security updates, given Renovate
     # is used to manage the regular dependency updates
     open-pull-requests-limit: 0
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
... because they are also handled by Renovate