### PR TITLE
Vert.x 4.4.5 is not needed anymore as a workaround for #973, since we use URLConnectionHTTPConduit by default that does not suffer from #973

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -46,13 +46,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.vertx</groupId>
-                <artifactId>vertx-dependencies</artifactId>
-                <version>4.4.5</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>


### PR DESCRIPTION
related #973 