### PR TITLE
Fixup HTTPS enforced via HttpsToken WS-SecurityPolicy does not work

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,6 +20,7 @@
         <module>logging</module>
         <module>ws-addressing</module>
         <module>ws-security-client</module>
+        <module>ws-security-policy</module>
         <module>ws-security-server</module>
         <module>ws-trust</module>
         <module>ws-rm</module>


### PR DESCRIPTION
fix #628