### PR TITLE
[Docs] Fix ws-rm server link after app split

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf-rt-ws-rm.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf-rt-ws-rm.adoc
@@ -65,7 +65,7 @@ There is an integration test covering WS-RM with a decoupled endpoint in the {qu
 
 It is split into two separate applications that communicate with each other:
 
-* https://github.com/quarkiverse/quarkus-cxf/tree/main/test-util-parent/test-ws-rm-server[Server]
+* https://github.com/quarkiverse/quarkus-cxf/tree/main/test-util-parent/test-ws-rm-server-jvm[Server]
 * https://github.com/quarkiverse/quarkus-cxf/tree/main/integration-tests/ws-rm-client[Client]
 
 To run it, you need to install the server into your local Maven repository first


### PR DESCRIPTION
@ppalaga I fixed only the link to point to the server-jvm, as the native doesn't contain the actual code. if you prefer, I can also add a link to the native app