### PR TITLE
IllegalArgumentException: port p must be in range 0 <= p <= 65535 when using client-endpoint-url without explicit port 

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
   attributes:
 
     # Versions
-    quarkus-version: 3.13.0 # replace ${quarkus.version}
+    quarkus-version: 3.13.1 # replace ${quarkus.version}
     quarkus-cxf-version: 3.13.1 # replace ${release.current-version}
 
     # Toggle whether some page elements are rendered

--- a/extensions/core/vertx-client/src/main/java/io/quarkiverse/cxf/vertx/http/client/VertxHttpClientHTTPConduit.java
+++ b/extensions/core/vertx-client/src/main/java/io/quarkiverse/cxf/vertx/http/client/VertxHttpClientHTTPConduit.java
@@ -160,10 +160,16 @@ public class VertxHttpClientHTTPConduit extends HTTPConduit {
                 : uri.getPath();
         requestOptions
                 .setMethod(method)
-                .setPort(uri.getPort())
                 .setHost(uri.getHost())
                 .setURI(pathAndQuery)
                 .setConnectTimeout(determineConnectionTimeout(message, csPolicy));
+
+        final int port = uri.getPort();
+        if (port >= 0) {
+            requestOptions
+                    .setPort(uri.getPort());
+        }
+
         final RequestContext requestContext = new RequestContext(
                 uri,
                 requestOptions,


### PR DESCRIPTION
Fix #1460