### PR TITLE
Missing dependency for OpenTelemetryCustomizer when OTEL is globally disabled

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf-integration-tracing-opentelemetry.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf-integration-tracing-opentelemetry.adoc
@@ -84,6 +84,10 @@ icon:lock[title=Fixed at build time] Configuration property fixed at build time.
 can be overridden per client or service endpoint using the `quarkus.cxf.client."client-name".otel.enabled` or
 `quarkus.cxf.endpoint."/endpoint-path".otel.enabled` option respectively.
 
+`quarkus.otel.enabled` and `quarkus.otel.sdk.disabled` also impact whether the CXF telemetry data is
+collected. Check https://quarkus.io/guides/opentelemetry#disable-all-or-parts-of-the-opentelemetry-extension[Quarkus
+OpenTelemetry guide].
+
 *Environment variable*: `+++QUARKUS_CXF_OTEL_ENABLED_FOR+++` +
 *Since Quarkus CXF*: 2.7.0
 
@@ -104,6 +108,11 @@ client.
 
 3+a|If `true` and if `quarkus.cxf.otel.enabled-for` is set to `both` or `services` then the `OpenTelemetryFeature`
 will be added to this service endpoint; otherwise the feature will not be added to this service endpoint.
+
+`quarkus.otel.enabled` and `quarkus.otel.sdk.disabled` also impact whether the CXF telemetry data is
+collected. Check
+https://quarkus.io/guides/opentelemetry#disable-all-or-parts-of-the-opentelemetry-extension[Quarkus OpenTelemetry
+guide].
 
 *Environment variable*: `+++QUARKUS_CXF_ENDPOINT___ENDPOINT_PATH__OTEL_ENABLED+++` +
 *Since Quarkus CXF*: 2.7.0

--- a/extensions/integration-tracing-opentelemetry/deployment/pom.xml
+++ b/extensions/integration-tracing-opentelemetry/deployment/pom.xml
@@ -24,6 +24,18 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry-deployment</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/integration-tracing-opentelemetry/deployment/src/main/java/io/quarkiverse/cxf/opentelemetry/deployment/QuarkusCxfOpenTelemetryProcessor.java
+++ b/extensions/integration-tracing-opentelemetry/deployment/src/main/java/io/quarkiverse/cxf/opentelemetry/deployment/QuarkusCxfOpenTelemetryProcessor.java
@@ -5,6 +5,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.opentelemetry.deployment.OpenTelemetryEnabled;
 
 public class QuarkusCxfOpenTelemetryProcessor {
 
@@ -15,7 +16,7 @@ public class QuarkusCxfOpenTelemetryProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = OpenTelemetryEnabled.class)
     void additionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         additionalBeans.produce(
                 new AdditionalBeanBuildItem(OpenTelemetryCustomizer.class));

--- a/extensions/integration-tracing-opentelemetry/deployment/src/test/java/io/quarkiverse/cxf/opentelemetry/deployment/OtelDisabledFalseTest.java
+++ b/extensions/integration-tracing-opentelemetry/deployment/src/test/java/io/quarkiverse/cxf/opentelemetry/deployment/OtelDisabledFalseTest.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.cxf.opentelemetry.deployment;
+
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebService;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.cxf.annotation.CXFClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OtelDisabledFalseTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloService.class, HelloServiceImpl.class))
+            .overrideConfigKey("quarkus.cxf.endpoint.\"/hello\".implementor",
+                    HelloServiceImpl.class.getName())
+
+            .overrideConfigKey("quarkus.otel.sdk.disabled", "true")
+
+            .overrideConfigKey("quarkus.cxf.client.hello.client-endpoint-url", "http://localhost:8081/services/hello")
+            .overrideConfigKey("quarkus.cxf.client.hello.service-interface", HelloService.class.getName());
+
+    @CXFClient("hello")
+    HelloService hello;
+
+    @Test
+    void otelDisabled() {
+        Assertions.assertThat(hello.hello("Joe with OTel disabled")).isEqualTo("Hello Joe with OTel disabled");
+    }
+
+    @WebService
+    public interface HelloService {
+
+        @WebMethod
+        String hello(String person);
+
+    }
+
+    @WebService(serviceName = "HelloService")
+    public static class HelloServiceImpl implements HelloService {
+
+        @Override
+        public String hello(String person) {
+            return "Hello " + person;
+        }
+    }
+
+}

--- a/extensions/integration-tracing-opentelemetry/deployment/src/test/java/io/quarkiverse/cxf/opentelemetry/deployment/OtelEnabledFalseTest.java
+++ b/extensions/integration-tracing-opentelemetry/deployment/src/test/java/io/quarkiverse/cxf/opentelemetry/deployment/OtelEnabledFalseTest.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.cxf.opentelemetry.deployment;
+
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebService;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.cxf.annotation.CXFClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OtelEnabledFalseTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloService.class, HelloServiceImpl.class))
+            .overrideConfigKey("quarkus.cxf.endpoint.\"/hello\".implementor",
+                    HelloServiceImpl.class.getName())
+
+            .overrideConfigKey("quarkus.otel.enabled", "false")
+
+            .overrideConfigKey("quarkus.cxf.client.hello.client-endpoint-url", "http://localhost:8081/services/hello")
+            .overrideConfigKey("quarkus.cxf.client.hello.service-interface", HelloService.class.getName());
+
+    @CXFClient("hello")
+    HelloService hello;
+
+    @Test
+    void otelDisabled() {
+        Assertions.assertThat(hello.hello("Joe with OTel disabled")).isEqualTo("Hello Joe with OTel disabled");
+    }
+
+    @WebService
+    public interface HelloService {
+
+        @WebMethod
+        String hello(String person);
+
+    }
+
+    @WebService(serviceName = "HelloService")
+    public static class HelloServiceImpl implements HelloService {
+
+        @Override
+        public String hello(String person) {
+            return "Hello " + person;
+        }
+    }
+
+}

--- a/extensions/integration-tracing-opentelemetry/runtime/src/main/java/io/quarkiverse/cxf/opentelemetry/CxfOpenTelemetryConfig.java
+++ b/extensions/integration-tracing-opentelemetry/runtime/src/main/java/io/quarkiverse/cxf/opentelemetry/CxfOpenTelemetryConfig.java
@@ -103,6 +103,11 @@ public interface CxfOpenTelemetryConfig {
              * If `true` and if `quarkus.cxf.otel.enabled-for` is set to `both` or `services` then the `OpenTelemetryFeature`
              * will be added to this service endpoint; otherwise the feature will not be added to this service endpoint.
              *
+             * `quarkus.otel.enabled` and `quarkus.otel.sdk.disabled` also impact whether the CXF telemetry data is
+             * collected. Check
+             * https://quarkus.io/guides/opentelemetry#disable-all-or-parts-of-the-opentelemetry-extension[Quarkus OpenTelemetry
+             * guide].
+             *
              * @since 2.7.0
              * @asciidoclet
              */
@@ -118,6 +123,10 @@ public interface CxfOpenTelemetryConfig {
          * Specifies whether the OpenTelemetry tracing will be enabled for clients, services, both or none. This global setting
          * can be overridden per client or service endpoint using the `quarkus.cxf.client."client-name".otel.enabled` or
          * `quarkus.cxf.endpoint."/endpoint-path".otel.enabled` option respectively.
+         *
+         * `quarkus.otel.enabled` and `quarkus.otel.sdk.disabled` also impact whether the CXF telemetry data is
+         * collected. Check https://quarkus.io/guides/opentelemetry#disable-all-or-parts-of-the-opentelemetry-extension[Quarkus
+         * OpenTelemetry guide].
          *
          * @since 2.7.0
          * @asciidoclet


### PR DESCRIPTION
fix #1476