### PR TITLE
Workaround for the bad initialization of HTTPTransportFactory.forceURLConnectionConduit in downstream CXF builds

### DIFF
--- a/docs/modules/ROOT/examples/hc5/Hc5Resource.java
+++ b/docs/modules/ROOT/examples/hc5/Hc5Resource.java
@@ -10,6 +10,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.frontend.ClientProxy;
 import org.jboss.eap.quickstarts.wscalculator.calculator.AddResponse;
 import org.jboss.eap.quickstarts.wscalculator.calculator.CalculatorService;
 
@@ -90,6 +92,14 @@ public class Hc5Resource {
     @Produces(MediaType.TEXT_PLAIN)
     public int addSyncContextPropagation(@QueryParam("a") int a, @QueryParam("b") int b) {
         return contextPropagationCalculator.add(a, b);
+    }
+
+    @Path("/conduit")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String conduit() {
+        final Client client = ClientProxy.getClient(myCalculator);
+        return client.getConduit().getClass().getName();
     }
 
     // tag::quarkus-cxf-rt-transports-http-hc5.usage.mutiny[]

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/CxfClientProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/CxfClientProcessor.java
@@ -22,6 +22,7 @@ import jakarta.xml.ws.BindingProvider;
 import jakarta.xml.ws.soap.SOAPBinding;
 
 import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.transport.http.HTTPTransportFactory;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
@@ -504,6 +505,22 @@ public class CxfClientProcessor {
                 throw new IllegalStateException("Unexpected " + HTTPConduitImpl.class.getSimpleName() + " value: "
                         + config.httpConduitFactory());
         }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void workaroundBadForceURLConnectionInit(CXFRecorder recorder) {
+        recorder.workaroundBadForceURLConnectionInit();
+    }
+
+    /**
+     * Allow some reflexive trickery in {@link CXFRecorder#workaroundBadForceURLConnectionInit()}.
+     *
+     * @return a new {@link ReflectiveClassBuildItem}
+     */
+    @BuildStep
+    ReflectiveClassBuildItem reflectiveClass() {
+        return ReflectiveClassBuildItem.builder(HTTPTransportFactory.class).fields().build();
     }
 
     private static class ProxyInfo {

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.cxf;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -7,6 +9,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.apache.cxf.Bus;
+import org.apache.cxf.transport.http.HTTPTransportFactory;
 import org.jboss.logging.Logger;
 
 import io.netty.util.internal.shaded.org.jctools.queues.MessagePassingQueue.Supplier;
@@ -280,6 +283,40 @@ public class CXFRecorder {
 
     public RuntimeValue<Consumer<Bus>> setBusHTTPConduitFactory(HTTPConduitImpl factory) {
         return new RuntimeValue<>(bus -> bus.setExtension(factory, HTTPConduitSpec.class));
+    }
+
+    public void workaroundBadForceURLConnectionInit() {
+        // A workaround for the bad initialization of HTTPTransportFactory.forceURLConnectionConduit
+        // in the downstream CXF 4.0.5.fuse-redhat-00012:
+        // private static boolean forceURLConnectionConduit
+        // = Boolean.valueOf(SystemPropertyAction.getProperty("org.apache.cxf.transport.http.forceURLConnection", "true"));
+        // Using default "true" breaks the backwards compatibility for us, so we set the property to false at application startup
+        // See also https://issues.redhat.com/browse/CEQ-10395
+        Field forceURLConnectionConduitField = null;
+        for (Field f : HTTPTransportFactory.class.getDeclaredFields()) {
+            if (f.getName().equals("forceURLConnectionConduit")) {
+                f.setAccessible(true);
+                forceURLConnectionConduitField = f;
+                break;
+            }
+        }
+
+        if (forceURLConnectionConduitField != null && Modifier.isStatic(forceURLConnectionConduitField.getModifiers())) {
+            /* We are on a CXF version having the static HTTPTransportFactory.forceURLConnectionConduit field */
+            try {
+                /*
+                 * If the property is null, but HTTPTransportFactory.forceURLConnectionConduit is true
+                 * then we are on a CXF version using the wrong default and we switch to default false
+                 */
+                if (forceURLConnectionConduitField.getBoolean(null)
+                        && System.getProperty("org.apache.cxf.transport.http.forceURLConnection") == null) {
+                    System.setProperty("org.apache.cxf.transport.http.forceURLConnection", "false");
+                    forceURLConnectionConduitField.set(null, false);
+                }
+            } catch (IllegalArgumentException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
 }

--- a/integration-tests/hc5/src/main/java/io/quarkiverse/cxf/hc5/it/Hc5Resource.java
+++ b/integration-tests/hc5/src/main/java/io/quarkiverse/cxf/hc5/it/Hc5Resource.java
@@ -10,6 +10,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.frontend.ClientProxy;
 import org.jboss.eap.quickstarts.wscalculator.calculator.AddResponse;
 import org.jboss.eap.quickstarts.wscalculator.calculator.CalculatorService;
 
@@ -90,6 +92,14 @@ public class Hc5Resource {
     @Produces(MediaType.TEXT_PLAIN)
     public int addSyncContextPropagation(@QueryParam("a") int a, @QueryParam("b") int b) {
         return contextPropagationCalculator.add(a, b);
+    }
+
+    @Path("/conduit")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String conduit() {
+        final Client client = ClientProxy.getClient(myCalculator);
+        return client.getConduit().getClass().getName();
     }
 
     // tag::quarkus-cxf-rt-transports-http-hc5.usage.mutiny[]

--- a/integration-tests/hc5/src/test/java/io/quarkiverse/cxf/hc5/it/Hc5Test.java
+++ b/integration-tests/hc5/src/test/java/io/quarkiverse/cxf/hc5/it/Hc5Test.java
@@ -134,6 +134,15 @@ class Hc5Test {
 
     }
 
+    @Test
+    void conduit() {
+        RestAssured.given()
+                .get("/hc5/conduit")
+                .then()
+                .statusCode(200)
+                .body(is("org.apache.cxf.transport.http.asyncclient.hc5.AsyncHTTPConduit"));
+    }
+
     private Map<String, Object> getMetrics() {
         final String body = RestAssured.given()
                 .header("Content-Type", "application/json")


### PR DESCRIPTION
Workaround for the bad initialization of HTTPTransportFactory.forceURLConnectionConduit in downstream CXF builds 4.0.5.fuse-redhat-00012 and possibly others