### PR TITLE
VertxHttpClientHTTPConduit connects to port 80 when the client-endpoint-url starts with https:// and has no explicit port

### DIFF
--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/vertx/http/client/VertxHttpClientHTTPConduit.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/vertx/http/client/VertxHttpClientHTTPConduit.java
@@ -187,8 +187,12 @@ public class VertxHttpClientHTTPConduit extends HTTPConduit {
 
         final int port = uri.getPort();
         if (port >= 0) {
-            requestOptions
-                    .setPort(uri.getPort());
+            /* Port was set explicitly */
+            requestOptions.setPort(uri.getPort());
+        } else if (isHttps) {
+            requestOptions.setPort(443);
+        } else {
+            requestOptions.setPort(80);
         }
 
         final RequestContext requestContext = new RequestContext(


### PR DESCRIPTION
fix #1646