### PR TITLE
Upgrade to Quarkus 3.19.0, Introduce quarkus.cxf.client.tls-configuration-name to set TLS options for all CXF clients 

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
   attributes:
 
     # Versions
-    quarkus-version: 3.19.0.CR1 # replace ${quarkus.version}
+    quarkus-version: 3.19.0 # replace ${quarkus.version}
     quarkus-cxf-version: 3.18.1 # replace ${release.current-version}
 
     # Toggle whether some page elements are rendered

--- a/docs/modules/ROOT/examples/client-server/application.properties
+++ b/docs/modules/ROOT/examples/client-server/application.properties
@@ -201,4 +201,11 @@ quarkus.cxf.client.retransmitCache.service-interface = io.quarkiverse.cxf.it.red
 quarkus.cxf.client.retransmitCache.auto-redirect = true
 #quarkus.cxf.client.retransmitCache.logging.enabled = true
 
+
+# ClientTlsTest
+# Server TLS is set in JavaNetSslClientTestResource
+quarkus.cxf.client.javaNetSslClient.client-endpoint-url = https://localhost:${quarkus.http.test-ssl-port}/soap/soap12
+quarkus.cxf.client.javaNetSslClient.service-interface = io.quarkiverse.cxf.it.HelloService
+quarkus.cxf.client.javaNetSslClient.logging.enabled = true
+
 quarkus.default-locale = en_US

--- a/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf.adoc
@@ -563,6 +563,42 @@ public class MyRestEasyResource {
 *Environment variable*: `+++QUARKUS_CXF_DECOUPLED_ENDPOINT_BASE+++` +
 *Since Quarkus CXF*: 2.7.0
 
+.<| [[quarkus-cxf_quarkus-cxf-client-tls-configuration-name]]`link:#quarkus-cxf_quarkus-cxf-client-tls-configuration-name[quarkus.cxf.client.tls-configuration-name]`
+.<| `string`
+.<| `javax.net.ssl`
+
+3+a|The name of the TLS configuration to use for setting up trust store and keystore for all clients. This setting can be
+overridden per client using
+`xref:#quarkus-cxf_quarkus-cxf-client-client-name-tls-configuration-name[quarkus.cxf.client."client-name".tls-configuration-name]`
+or (deprecated) `xref:reference/extensions/quarkus-cxf.adoc#quarkus-cxf_quarkus-cxf-client-client-name-trust-store[quarkus.cxf.client."client-name".trust-store*]`
+and (deprecated) `xref:reference/extensions/quarkus-cxf.adoc#quarkus-cxf_quarkus-cxf-client-client-name-key-store[quarkus.cxf.client."client-name".key-store*]`
+options.
+
+For each client, if the per-client `.tls-configuration-name` or `.trust-store` or `.key-store` is configured then the
+relevant per client configuration will be used.
+Otherwise, this configuration will be used.
+
+By default value `javax.net.ssl` is a special named TLS configuration provided by Quarkus.
+It exists since Quarkus 3.19.0 and can be characterized as follows:
+
+* If the `javax.net.ssl.trustStore` system property is defined, then its value is honored as a truststore
+* Otherwise, the paths `$JAVA_HOME/lib/security/jssecacerts` and `$JAVA_HOME/lib/security/cacerts` are checked
+and the first existing file is used as a truststore
+* Otherwise an `IllegalStateException` is thrown.
+* The password for opening the truststore is taken from the `javax.net.ssl.trustStorePassword` system property.
+  If it is not set, the default password `changeit` is used.
+
+[NOTE]
+====
+We chose `javax.net.ssl` as a default for better compatibility of `VertxHttpClientHTTPConduit` with
+`URLConnectionHTTPConduit`.
+Other Quarkus extensions do not take `javax.net.ssl.trustStore` system property or
+`$JAVA_HOME/lib/security/*cacerts` files into account by default.
+====
+
+*Environment variable*: `+++QUARKUS_CXF_CLIENT_TLS_CONFIGURATION_NAME+++` +
+*Since Quarkus CXF*: 3.19.0
+
 .<| [[quarkus-cxf_quarkus-cxf-logging-enabled-for]]`link:#quarkus-cxf_quarkus-cxf-logging-enabled-for[quarkus.cxf.logging.enabled-for]`
 .<| `clients`, `services`, `both`, `none`
 .<| `none`
@@ -2054,6 +2090,8 @@ and `.key-store*` family of options will be used.
 If a name is configured, it uses the configuration from `quarkus.tls.<name>.*`
 If a name is configured, but no TLS configuration is found with that name then an error will be thrown at runtime.
 Setting `.tls-configuration-name` and any of `.trust-store` or `.key-store` leads to an exception at runtime.
+If none of `.tls-configuration-name`, `.trust-store` or `.key-store` is set, the default configuration is given by
+`xref:#quarkus-cxf_quarkus-cxf-client-tls-configuration-name[quarkus.cxf.client.tls-configuration-name]`
 
 *Environment variable*: `+++QUARKUS_CXF_CLIENT__CLIENT_NAME__TLS_CONFIGURATION_NAME+++` +
 *Since Quarkus CXF*: 3.15.0

--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/GlobalTlsConfigurationTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/GlobalTlsConfigurationTest.java
@@ -1,0 +1,112 @@
+package io.quarkiverse.cxf.deployment.test;
+
+import jakarta.inject.Inject;
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebService;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.cxf.annotation.CXFClient;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/classes", //
+        certificates = @Certificate( //
+                name = "localhost", //
+                password = "secret", //
+                formats = { Format.PKCS12 }))
+public class GlobalTlsConfigurationTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloService.class, HelloServiceImpl.class))
+
+            /* Server TLS */
+            .overrideConfigKey("quarkus.tls.localhost-pkcs12.key-store.p12.path", "localhost-keystore.p12")
+            .overrideConfigKey("quarkus.tls.localhost-pkcs12.key-store.p12.password", "secret")
+            .overrideConfigKey("quarkus.http.tls-configuration-name", "localhost-pkcs12")
+            .overrideConfigKey("quarkus.http.insecure-requests", "disabled")
+            /* Service */
+            .overrideConfigKey("quarkus.cxf.endpoint.\"/hello\".implementor",
+                    HelloServiceImpl.class.getName())
+            .overrideConfigKey("quarkus.cxf.endpoint.\"/hello\".logging.enabled", "true")
+
+            /* Named TLS configuration for the clients */
+            .overrideConfigKey("quarkus.tls.client-pkcs12.trust-store.p12.path", "target/classes/localhost-truststore.p12")
+            .overrideConfigKey("quarkus.tls.client-pkcs12.trust-store.p12.password", "secret")
+            /* Global TLS config name for all clients */
+            .overrideConfigKey("quarkus.cxf.client.tls-configuration-name", "client-pkcs12")
+
+            /* Client with VertxHttpClientHTTPConduitFactory */
+            .overrideConfigKey("quarkus.cxf.client.helloVertx.client-endpoint-url", "https://localhost:8444/services/hello")
+            .overrideConfigKey("quarkus.cxf.client.helloVertx.logging.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.client.helloVertx.service-interface", HelloService.class.getName())
+            .overrideConfigKey("quarkus.cxf.client.helloVertx.http-conduit-factory", "VertxHttpClientHTTPConduitFactory")
+
+            /* Client with HttpClientHTTPConduitFactory */
+            .overrideConfigKey("quarkus.cxf.client.helloHttpClient.client-endpoint-url",
+                    "https://localhost:8444/services/hello")
+            .overrideConfigKey("quarkus.cxf.client.helloHttpClient.logging.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.client.helloHttpClient.service-interface", HelloService.class.getName())
+            .overrideConfigKey("quarkus.cxf.client.helloHttpClient.http-conduit-factory", "HttpClientHTTPConduitFactory")
+
+            /* Client with URLConnectionHTTPConduitFactory */
+            .overrideConfigKey("quarkus.cxf.client.helloUrlConnection.client-endpoint-url",
+                    "https://localhost:8444/services/hello")
+            .overrideConfigKey("quarkus.cxf.client.helloUrlConnection.logging.enabled", "true")
+            .overrideConfigKey("quarkus.cxf.client.helloUrlConnection.service-interface", HelloService.class.getName())
+            .overrideConfigKey("quarkus.cxf.client.helloUrlConnection.http-conduit-factory", "URLConnectionHTTPConduitFactory");
+
+    @CXFClient("helloVertx")
+    HelloService helloVertx;
+
+    @CXFClient("helloHttpClient")
+    HelloService helloHttpClient;
+
+    @CXFClient("helloUrlConnection")
+    HelloService helloUrlConnection;
+
+    @Inject
+    Logger logger;
+
+    @Test
+    void vertx() {
+        Assertions.assertThat(helloVertx.hello("Doe")).isEqualTo("Hello Doe");
+    }
+
+    @Test
+    void httpClient() {
+        Assertions.assertThat(helloHttpClient.hello("Doe")).isEqualTo("Hello Doe");
+    }
+
+    @Test
+    void urlConnection() {
+        Assertions.assertThat(helloUrlConnection.hello("Doe")).isEqualTo("Hello Doe");
+    }
+
+    @WebService
+    public interface HelloService {
+
+        @WebMethod
+        String hello(String person);
+
+    }
+
+    @WebService(serviceName = "HelloService")
+    public static class HelloServiceImpl implements HelloService {
+
+        @Override
+        public String hello(String person) {
+            return "Hello " + person;
+        }
+    }
+
+}

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfClientConfig.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfClientConfig.java
@@ -485,6 +485,8 @@ public interface CxfClientConfig {
      * If a name is configured, it uses the configuration from `quarkus.tls.<name>.*`
      * If a name is configured, but no TLS configuration is found with that name then an error will be thrown at runtime.
      * Setting `.tls-configuration-name` and any of `.trust-store` or `.key-store` leads to an exception at runtime.
+     * If none of `.tls-configuration-name`, `.trust-store` or `.key-store` is set, the default configuration is given by
+     * `xref:#quarkus-cxf_quarkus-cxf-client-tls-configuration-name[quarkus.cxf.client.tls-configuration-name]`
      *
      * @asciidoclet
      * @since 3.15.0

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfConfig.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfConfig.java
@@ -98,13 +98,19 @@ public interface CxfConfig {
     public Map<String, CxfEndpointConfig> endpoints();
 
     /**
+     * Global client related configurations.
+     *
+     * @asciidoclet
+     */
+    public CxfGlobalClientConfig client();
+
+    /**
      * Configure client proxies.
      *
      * @asciidoclet
      */
     @WithName("client")
     @ConfigDocMapKey("client-name")
-
     @WithDefaults
     public Map<String, CxfClientConfig> clients();
 
@@ -136,6 +142,47 @@ public interface CxfConfig {
 
     default CxfClientConfig getClient(String key) {
         return Optional.ofNullable(clients()).map(m -> m.get(key)).orElse(null);
+    }
+
+    public interface CxfGlobalClientConfig {
+        // The formatter breaks the list with long items
+        // @formatter:off
+        /**
+         * The name of the TLS configuration to use for setting up trust store and keystore for all clients. This setting can be
+         * overridden per client using
+         * `xref:#quarkus-cxf_quarkus-cxf-client-client-name-tls-configuration-name[quarkus.cxf.client."client-name".tls-configuration-name]`
+         * or (deprecated) `xref:reference/extensions/quarkus-cxf.adoc#quarkus-cxf_quarkus-cxf-client-client-name-trust-store[quarkus.cxf.client."client-name".trust-store*]`
+         * and (deprecated) `xref:reference/extensions/quarkus-cxf.adoc#quarkus-cxf_quarkus-cxf-client-client-name-key-store[quarkus.cxf.client."client-name".key-store*]`
+         * options.
+         *
+         * For each client, if the per-client `.tls-configuration-name` or `.trust-store` or `.key-store` is configured then the
+         * relevant per client configuration will be used.
+         * Otherwise, this configuration will be used.
+         *
+         * By default value `javax.net.ssl` is a special named TLS configuration provided by Quarkus.
+         * It exists since Quarkus 3.19.0 and can be characterized as follows:
+         *
+         * * If the `javax.net.ssl.trustStore` system property is defined, then its value is honored as a truststore
+         * * Otherwise, the paths `$JAVA_HOME/lib/security/jssecacerts` and `$JAVA_HOME/lib/security/cacerts` are checked
+         * and the first existing file is used as a truststore
+         * * Otherwise an `IllegalStateException` is thrown.
+         * * The password for opening the truststore is taken from the `javax.net.ssl.trustStorePassword` system property.
+         *   If it is not set, the default password `changeit` is used.
+         *
+         * [NOTE]
+         * ====
+         * We chose `javax.net.ssl` as a default for better compatibility of `VertxHttpClientHTTPConduit` with
+         * `URLConnectionHTTPConduit`.
+         * Other Quarkus extensions do not take `javax.net.ssl.trustStore` system property or
+         * `$JAVA_HOME/lib/security/*cacerts` files into account by default.
+         * ====
+         *
+         * @asciidoclet
+         * @since 3.19.0
+         */
+        // @formatter:on
+        @WithDefault("javax.net.ssl")
+        public String tlsConfigurationName();
     }
 
     public interface InternalConfig {

--- a/integration-tests/client-server/pom.xml
+++ b/integration-tests/client-server/pom.xml
@@ -47,6 +47,11 @@
              <artifactId>mockito-core</artifactId>
              <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.certs</groupId>
+            <artifactId>smallrye-certificate-generator</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/client-server/src/main/java/io/quarkiverse/cxf/it/client/tls/JavaNetSslClientRest.java
+++ b/integration-tests/client-server/src/main/java/io/quarkiverse/cxf/it/client/tls/JavaNetSslClientRest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.cxf.it.client.tls;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkiverse.cxf.annotation.CXFClient;
+import io.quarkiverse.cxf.it.HelloService;
+import io.quarkus.logging.Log;
+
+@Path("/JavaNetSslClient")
+public class JavaNetSslClientRest {
+
+    @CXFClient("javaNetSslClient")
+    HelloService javaNetSslClient;
+
+    HelloService getClient(String clientName) {
+        switch (clientName) {
+            case "javaNetSslClient": {
+                return javaNetSslClient;
+            }
+            default:
+                throw new IllegalArgumentException("Unexpected client name: " + clientName);
+        }
+    }
+
+    @Path("/sync/{client}")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello(@PathParam("client") String client, String body) {
+        Log.infof("javax.net.ssl.trustStore = %s", System.getProperty("javax.net.ssl.trustStore"));
+        return getClient(client).hello(body);
+    }
+
+}

--- a/integration-tests/client-server/src/main/resources/application.properties
+++ b/integration-tests/client-server/src/main/resources/application.properties
@@ -201,4 +201,11 @@ quarkus.cxf.client.retransmitCache.service-interface = io.quarkiverse.cxf.it.red
 quarkus.cxf.client.retransmitCache.auto-redirect = true
 #quarkus.cxf.client.retransmitCache.logging.enabled = true
 
+
+# ClientTlsTest
+# Server TLS is set in JavaNetSslClientTestResource
+quarkus.cxf.client.javaNetSslClient.client-endpoint-url = https://localhost:${quarkus.http.test-ssl-port}/soap/soap12
+quarkus.cxf.client.javaNetSslClient.service-interface = io.quarkiverse.cxf.it.HelloService
+quarkus.cxf.client.javaNetSslClient.logging.enabled = true
+
 quarkus.default-locale = en_US

--- a/integration-tests/client-server/src/test/java/io/quarkiverse/cxf/it/client/tls/JavaNetSslClientIT.java
+++ b/integration-tests/client-server/src/test/java/io/quarkiverse/cxf/it/client/tls/JavaNetSslClientIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.cxf.it.client.tls;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class JavaNetSslClientIT extends JavaNetSslClientTest {
+
+}

--- a/integration-tests/client-server/src/test/java/io/quarkiverse/cxf/it/client/tls/JavaNetSslClientTest.java
+++ b/integration-tests/client-server/src/test/java/io/quarkiverse/cxf/it/client/tls/JavaNetSslClientTest.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.cxf.it.client.tls;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@QuarkusTestResource(JavaNetSslClientTestResource.class)
+class JavaNetSslClientTest {
+    @Test
+    void javaNetSslClient() {
+        RestAssured
+                .given()
+                .body("Jane")
+                .post("/JavaNetSslClient/sync/javaNetSslClient")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("Hello Jane, Content-Type: text/xml; charset=UTF-8"));
+    }
+}

--- a/integration-tests/client-server/src/test/java/io/quarkiverse/cxf/it/client/tls/JavaNetSslClientTestResource.java
+++ b/integration-tests/client-server/src/test/java/io/quarkiverse/cxf/it/client/tls/JavaNetSslClientTestResource.java
@@ -1,0 +1,111 @@
+package io.quarkiverse.cxf.it.client.tls;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+
+public class JavaNetSslClientTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private String originalTrustStore;
+
+    @Override
+    public Map<String, String> start() {
+        try {
+
+            /*
+             * Copy $JAVA_HOME/lib/security/cacerts to target/certs,
+             * add the localhost certificate into it
+             * and set javax.net.ssl.trustStore system property to the modified trust store's path
+             */
+            final Path certsDir = Path.of("target/certs");
+            Files.createDirectories(certsDir);
+            final String localhostPassword = "changeit";
+            new CertificateGenerator(certsDir, true).generate(new CertificateRequest()
+                    .withName("localhost")
+                    .withFormat(Format.PKCS12)
+                    .withPassword(localhostPassword)
+                    .withDuration(Duration.ofDays(2))
+                    .withCN("localhost"));
+
+            final String tsType = System.getProperty("javax.net.ssl.trustStoreType", KeyStore.getDefaultType())
+                    .toLowerCase(Locale.US);
+            final Path systemCacertsPath = defaultTrustStorePath();
+            final Path cacertsWithLocalhost = certsDir
+                    .resolve("cacerts-with-localhost." + (tsType.equals("pkcs12") ? "p12" : tsType));
+            final String cacertsPassword = System.getProperty("javax.net.ssl.trustStorePassword", "changeit");
+
+            final KeyStore cacerts = KeyStore.getInstance(tsType);
+            try (InputStream in = Files.newInputStream(systemCacertsPath)) {
+                cacerts.load(in, cacertsPassword.toCharArray());
+            }
+
+            final KeyStore localhostTruststore = KeyStore.getInstance("PKCS12");
+            try (InputStream in = Files.newInputStream(certsDir.resolve("localhost-truststore.p12"))) {
+                localhostTruststore.load(in, localhostPassword.toCharArray());
+            }
+            cacerts.setCertificateEntry("localhost", localhostTruststore.getCertificate("localhost"));
+
+            try (OutputStream out = Files.newOutputStream(cacertsWithLocalhost)) {
+                cacerts.store(out, cacertsPassword.toCharArray());
+            }
+
+            this.originalTrustStore = System.getProperty("javax.net.ssl.trustStore");
+            System.setProperty("javax.net.ssl.trustStore", cacertsWithLocalhost.toString());
+
+            return Map.of(
+                    "javax.net.ssl.trustStore", cacertsWithLocalhost.toString(),
+                    "quarkus.tls.localhost-pkcs12.key-store.p12.path", certsDir.resolve("localhost-keystore.p12").toString(),
+                    "quarkus.tls.localhost-pkcs12.key-store.p12.password", localhostPassword,
+                    "quarkus.http.tls-configuration-name", "localhost-pkcs12");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Path defaultTrustStorePath() {
+        final String rawTsPath = System.getProperty("javax.net.ssl.trustStore");
+        if (rawTsPath != null && !rawTsPath.isEmpty()) {
+            return Path.of(rawTsPath);
+        }
+        final String javaHome = System.getProperty("java.home");
+        if (javaHome == null || javaHome.isEmpty()) {
+            throw new IllegalStateException(
+                    "Could not locate the default Java truststore because the 'java.home' property is not set");
+        }
+        final Path javaHomePath = Path.of(javaHome);
+        if (!Files.isDirectory(javaHomePath)) {
+            throw new IllegalStateException("Could not locate the default Java truststore because the 'java.home' path '"
+                    + javaHome + "' is not a directory");
+        }
+        final Path jssecacerts = javaHomePath.resolve("lib/security/jssecacerts");
+        if (Files.isRegularFile(jssecacerts)) {
+            return jssecacerts;
+        }
+        final Path cacerts = javaHomePath.resolve("lib/security/cacerts");
+        if (Files.isRegularFile(cacerts)) {
+            return cacerts;
+        }
+        throw new IllegalStateException(
+                "Could not locate the default Java truststore. Tried javax.net.ssl.trustStore system property, " + jssecacerts
+                        + " and " + cacerts);
+    }
+
+    @Override
+    public void stop() {
+        if (originalTrustStore == null) {
+            System.getProperties().remove("javax.net.ssl.trustStore");
+        } else {
+            System.setProperty("javax.net.ssl.trustStore", originalTrustStore);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     </developers>
     <properties>
         <!-- Primary dependencies -->
-        <quarkus.version>3.19.0.CR1</quarkus.version>
+        <quarkus.version>3.19.0</quarkus.version>
         <cxf.version>4.1.0</cxf.version>
         <quarkus-enforcer-rules.version>${quarkus.version}</quarkus-enforcer-rules.version>
         <quarkus-antora.version>1.1.0</quarkus-antora.version>


### PR DESCRIPTION
Fix #1680