### PR TITLE
Dev UI: always produce JsonRPCProvidersBuildItem

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/devui/DevUIProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/devui/DevUIProcessor.java
@@ -48,7 +48,7 @@ public class DevUIProcessor {
         return cardPageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(CxfJsonRPCService.class);
     }


### PR DESCRIPTION
This is due to an upcoming change in Execution Model Validation [1] where we need the `JsonRPCProvidersBuildItem` produced always, not only in dev mode. JSON RPC providers can use execution model affecting annotations, so we need to know about them, otherwise a non-dev build would fail with an incorrect validation error.

[1] https://github.com/quarkusio/quarkus/pull/46965