### PR TITLE
Access keystores generated by smallrye-certificate-generator-junit5 only

### DIFF
--- a/docs/modules/ROOT/examples/mtls/application.properties
+++ b/docs/modules/ROOT/examples/mtls/application.properties
@@ -4,12 +4,12 @@ keystore.type.short = p12
 
 # tag::mtls[]
 # Server keystore for Simple TLS
-quarkus.tls.localhost-pkcs12.key-store.p12.path = localhost-keystore.p12
+quarkus.tls.localhost-pkcs12.key-store.p12.path = target/classes/localhost-keystore.p12
 quarkus.tls.localhost-pkcs12.key-store.p12.password = secret
 quarkus.tls.localhost-pkcs12.key-store.p12.alias = localhost
 quarkus.tls.localhost-pkcs12.key-store.p12.alias-password = secret
 # Server truststore for Mutual TLS
-quarkus.tls.localhost-pkcs12.trust-store.p12.path = localhost-server-truststore.p12
+quarkus.tls.localhost-pkcs12.trust-store.p12.path = target/classes/localhost-server-truststore.p12
 quarkus.tls.localhost-pkcs12.trust-store.p12.password = secret
 # Select localhost-pkcs12 as the TLS configuration for the HTTP server
 quarkus.http.tls-configuration-name = localhost-pkcs12
@@ -34,7 +34,7 @@ quarkus.tls.client-pkcs12.trust-store.p12.path = target/classes/localhost-trusts
 quarkus.tls.client-pkcs12.trust-store.p12.password = secret
 
 # Include the keystores in the native executable
-quarkus.native.resources.includes = *.pkcs12,*.jks
+quarkus.native.resources.includes = *.p12,*.jks
 # end::mtls[]
 
 # CXF client configured for mTLS in the old way
@@ -52,6 +52,6 @@ quarkus.cxf.client.mTlsOld.trust-store-password = secret
 # CXF client without keystore (to test the failing case)
 quarkus.cxf.client.noKeystore.client-endpoint-url = https://localhost:${quarkus.http.test-ssl-port}/services/mTls
 quarkus.cxf.client.noKeystore.service-interface = io.quarkiverse.cxf.it.security.policy.HelloService
-quarkus.cxf.client.noKeystore.trust-store = localhost-truststore.p12
+quarkus.cxf.client.noKeystore.trust-store = target/classes/localhost-truststore.p12
 quarkus.cxf.client.noKeystore.trust-store-type = pkcs12
 quarkus.cxf.client.noKeystore.trust-store-password = secret

--- a/integration-tests/mtls/src/main/resources/application.properties
+++ b/integration-tests/mtls/src/main/resources/application.properties
@@ -4,12 +4,12 @@ keystore.type.short = ${keystore.type.short}
 
 # tag::mtls[]
 # Server keystore for Simple TLS
-quarkus.tls.localhost-${keystore.type}.key-store.${keystore.type.short}.path = localhost-keystore.${keystore.type.short}
+quarkus.tls.localhost-${keystore.type}.key-store.${keystore.type.short}.path = target/classes/localhost-keystore.${keystore.type.short}
 quarkus.tls.localhost-${keystore.type}.key-store.${keystore.type.short}.password = secret
 quarkus.tls.localhost-${keystore.type}.key-store.${keystore.type.short}.alias = localhost
 quarkus.tls.localhost-${keystore.type}.key-store.${keystore.type.short}.alias-password = secret
 # Server truststore for Mutual TLS
-quarkus.tls.localhost-${keystore.type}.trust-store.${keystore.type.short}.path = localhost-server-truststore.${keystore.type.short}
+quarkus.tls.localhost-${keystore.type}.trust-store.${keystore.type.short}.path = target/classes/localhost-server-truststore.${keystore.type.short}
 quarkus.tls.localhost-${keystore.type}.trust-store.${keystore.type.short}.password = secret
 # Select localhost-${keystore.type} as the TLS configuration for the HTTP server
 quarkus.http.tls-configuration-name = localhost-${keystore.type}
@@ -34,7 +34,7 @@ quarkus.tls.client-${keystore.type}.trust-store.${keystore.type.short}.path = ta
 quarkus.tls.client-${keystore.type}.trust-store.${keystore.type.short}.password = secret
 
 # Include the keystores in the native executable
-quarkus.native.resources.includes = *.pkcs12,*.jks
+quarkus.native.resources.includes = *.p12,*.jks
 # end::mtls[]
 
 # CXF client configured for mTLS in the old way
@@ -52,6 +52,6 @@ quarkus.cxf.client.mTlsOld.trust-store-password = secret
 # CXF client without keystore (to test the failing case)
 quarkus.cxf.client.noKeystore.client-endpoint-url = https://localhost:${quarkus.http.test-ssl-port}/services/mTls
 quarkus.cxf.client.noKeystore.service-interface = io.quarkiverse.cxf.it.security.policy.HelloService
-quarkus.cxf.client.noKeystore.trust-store = localhost-truststore.${keystore.type.short}
+quarkus.cxf.client.noKeystore.trust-store = target/classes/localhost-truststore.${keystore.type.short}
 quarkus.cxf.client.noKeystore.trust-store-type = ${keystore.type}
 quarkus.cxf.client.noKeystore.trust-store-password = secret

--- a/integration-tests/santuario-xmlsec/src/main/java/io/quarkiverse/xmlsec/it/XmlsecResource.java
+++ b/integration-tests/santuario-xmlsec/src/main/java/io/quarkiverse/xmlsec/it/XmlsecResource.java
@@ -17,6 +17,8 @@
 package io.quarkiverse.xmlsec.it;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -49,9 +51,11 @@ public class XmlsecResource {
     public XmlsecResource() throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
         // Set up the Key
         keyStore = KeyStore.getInstance("pkcs12");
-        keyStore.load(
-                this.getClass().getClassLoader().getResource("localhost-keystore.p12").openStream(),
-                LOCALHOST_KEYSTORE_PASSWORD.toCharArray());
+        try (InputStream in = Files.newInputStream(java.nio.file.Path.of("target/classes/localhost-keystore.p12"))) {
+            keyStore.load(
+                    in,
+                    LOCALHOST_KEYSTORE_PASSWORD.toCharArray());
+        }
     }
 
     /**
@@ -109,9 +113,11 @@ public class XmlsecResource {
 
         // Set up the Key
         KeyStore keyStore = KeyStore.getInstance("pkcs12");
-        keyStore.load(
-                this.getClass().getClassLoader().getResource("localhost-client-keystore.p12").openStream(),
-                LOCALHOST_KEYSTORE_PASSWORD.toCharArray());
+        try (InputStream in = Files.newInputStream(java.nio.file.Path.of("target/classes/localhost-client-keystore.p12"))) {
+            keyStore.load(
+                    in,
+                    LOCALHOST_KEYSTORE_PASSWORD.toCharArray());
+        }
         Key key = keyStore.getKey("client", CLIENT_KEYSTORE_PASSWORD.toCharArray());
         X509Certificate cert = (X509Certificate) keyStore.getCertificate("client");
         return signature.sign(plaintext, key, cert, PAYMENT_INFO);
@@ -132,9 +138,11 @@ public class XmlsecResource {
 
         // Set up the Key
         KeyStore keyStore = KeyStore.getInstance("pkcs12");
-        keyStore.load(
-                this.getClass().getClassLoader().getResource("localhost-client-keystore.p12").openStream(),
-                LOCALHOST_KEYSTORE_PASSWORD.toCharArray());
+        try (InputStream in = Files.newInputStream(java.nio.file.Path.of("target/classes/localhost-client-keystore.p12"))) {
+            keyStore.load(
+                    in,
+                    LOCALHOST_KEYSTORE_PASSWORD.toCharArray());
+        }
         X509Certificate cert = (X509Certificate) keyStore.getCertificate("client");
         signature.verify(plaintext, cert);
     }


### PR DESCRIPTION
via local path because they are not accessible via class loader in native mode when the tests are run on the platform