### PR TITLE
Upgrade to Quarkus Antora 1.3.0, Getting 429 Too Many Requests when GET-ting https://github.com/<org>/<repo>/(?:blob|tree)/.* links

### DIFF
--- a/docs/src/test/java/io/quarkiverse/cxf/doc/it/AntoraTest.java
+++ b/docs/src/test/java/io/quarkiverse/cxf/doc/it/AntoraTest.java
@@ -12,6 +12,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.antorassured.AntorAssured;
+import io.quarkiverse.antorassured.RateLimit;
 import io.quarkiverse.antorassured.ResourceResolver;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -45,6 +46,7 @@ public class AntoraTest {
                 .links()
                 .excludeResolved(Pattern.compile("^\\Qhttp://localhost:808\\E[02].*"))
                 .excludeEditThisPage()
+                .rateLimit("https://github.com/[^/]+/[^/]+/(?:blob|tree)/.*", RateLimit.requestsPerTimeInterval(4, 61_000L))
                 .validate()
                 .ignore(err -> ignorables.contains(err.uri().resolvedUri()))
                 .assertValid();

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <quarkus.version>3.22.1</quarkus.version>
         <cxf.version>4.1.1</cxf.version>
         <quarkus-enforcer-rules.version>${quarkus.version}</quarkus-enforcer-rules.version>
-        <quarkus-antora.version>1.3.0</quarkus-antora.version>
+        <quarkus-antora.version>1.4.0</quarkus-antora.version>
 
         <!-- Other compile dependency versions (keep sorted alphabetically) -->
         <!-- Items annotated with @sync can be updated by running mvn cq:sync-versions -N -->


### PR DESCRIPTION
fix #1804