### PR TITLE
Avoid Getting 429 Too Many Requests when GET-ting https://github.com/…<org>/<repo>/(?:blob|tree)/.* by using https://api.github.com/repos/OWNER/REPO/contents/PATH instead

### DIFF
--- a/.github/actions/build-and-run-jvm-tests/action.yml
+++ b/.github/actions/build-and-run-jvm-tests/action.yml
@@ -14,6 +14,9 @@ inputs:
       If true, the local Maven repository will be tar-gzipped and uploaded using actions/upload-artifact;
       otherwise it will neither be tar-gzipped nor uploaded
     default: 'true'
+  token:
+    description: "The token to use to authenticate against GitHub API"
+    required: true
 
 runs:
   using: 'composite'
@@ -27,12 +30,15 @@ runs:
 
     - name: mvn -B formatter:validate install
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: ./mvnw -B formatter:validate install -fae -ntp ${{ inputs.run-native-tests == 'true' && '-Pnative -Dquarkus.native.container-build' || '' }}
 
     # Same as the previous but only JVM tests and different default ConduitFactory
     - name: QUARKUS_CXF_DEFAULT_HTTP_CONDUIT_FACTORY=URLConnectionHTTPConduitFactory mvn -B test
       shell: bash
       env: 
+        GITHUB_TOKEN: ${{ inputs.token }}
         QUARKUS_CXF_DEFAULT_HTTP_CONDUIT_FACTORY: URLConnectionHTTPConduitFactory
       run: ./mvnw -B clean install -fae -ntp ${{ inputs.run-native-tests == 'true' && '-Pnative -Dquarkus.native.container-build' || '' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,8 @@ jobs:
 
     - name: build-and-run-jvm-tests
       uses: ./.github/actions/build-and-run-jvm-tests
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
   native-tests:
     strategy:

--- a/.github/workflows/rebase-integration-branch.yml
+++ b/.github/workflows/rebase-integration-branch.yml
@@ -85,6 +85,7 @@ jobs:
       with:
         run-native-tests: 'true'
         upload-local-maven-repo-archive: 'false'
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: git push origin ${{ matrix.dependency-short-name }}-${{ matrix.dependency-stream }} -f
       shell: bash

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
   attributes:
 
     # Versions
-    quarkus-version: 3.22.1 # replace ${quarkus.version}
+    quarkus-version: 3.22.2 # replace ${quarkus.version}
     quarkus-cxf-version: 3.22.0 # replace ${release.current-version}
 
     # Toggle whether some page elements are rendered

--- a/docs/src/test/java/io/quarkiverse/cxf/doc/it/AntoraTest.java
+++ b/docs/src/test/java/io/quarkiverse/cxf/doc/it/AntoraTest.java
@@ -8,11 +8,14 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 
+import org.assertj.core.api.Assertions;
 import org.hamcrest.CoreMatchers;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.antorassured.AntorAssured;
-import io.quarkiverse.antorassured.RateLimit;
+import io.quarkiverse.antorassured.LinkGroupFactory;
+import io.quarkiverse.antorassured.LinkStream;
 import io.quarkiverse.antorassured.ResourceResolver;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -20,6 +23,8 @@ import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class AntoraTest {
+
+    private static final Logger log = Logger.getLogger(AntoraTest.class);
 
     @Test
     public void antoraSite() throws TimeoutException, IOException, InterruptedException {
@@ -42,11 +47,31 @@ public class AntoraTest {
             ignorables.add("https://quarkus.io/blog/quarkus-3-22-0-released/");
         }
 
-        AntorAssured
+        LinkStream linkStream = AntorAssured
                 .links()
                 .excludeResolved(Pattern.compile("^\\Qhttp://localhost:808\\E[02].*"))
                 .excludeEditThisPage()
-                .rateLimit("https://github.com/[^/]+/[^/]+/(?:blob|tree)/.*", RateLimit.requestsPerTimeInterval(4, 61_000L))
+                .overallTimeout(120_000L);
+
+        final String ghToken = System.getenv("GITHUB_TOKEN");
+        if (ghToken == null) {
+            if (Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"))) {
+                Assertions.fail(
+                        "Set GITHUB_TOKEN environment variable to test GitHub links - see https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28");
+            } else {
+                log.warn(
+                        "Set GITHUB_TOKEN environment variable to test GitHub links - see https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28");
+                linkStream = linkStream
+                        .excludeResolved(Pattern.compile("https://github.com/[^/]+/[^/]+/(:?blob|tree)/.*"));
+            }
+        } else {
+            log.info("GITHUB_TOKEN set");
+            linkStream = linkStream
+                    .group(LinkGroupFactory.gitHubRawBlobLinks(ghToken))
+                    .endGroup();
+        }
+
+        linkStream
                 .validate()
                 .ignore(err -> ignorables.contains(err.uri().resolvedUri()))
                 .assertValid();

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <quarkus.version>3.22.2</quarkus.version>
         <cxf.version>4.1.1</cxf.version>
         <quarkus-enforcer-rules.version>${quarkus.version}</quarkus-enforcer-rules.version>
-        <quarkus-antora.version>1.4.0</quarkus-antora.version>
+        <quarkus-antora.version>2.0.0.CR1</quarkus-antora.version>
 
         <!-- Other compile dependency versions (keep sorted alphabetically) -->
         <!-- Items annotated with @sync can be updated by running mvn cq:sync-versions -N -->


### PR DESCRIPTION
fix #1804