### PR TITLE
Remove debugging output statement

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/codegen/Wsdl2JavaCodeGen.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/codegen/Wsdl2JavaCodeGen.java
@@ -282,7 +282,6 @@ public class Wsdl2JavaCodeGen implements CodeGenProvider {
                 WithDefault withDefault, Consumer<String> paramConsumer) {
             switch (wsdl2JavaParam.transformer()) {
                 case bool:
-                    System.out.println("bool " + value + " " + value.getClass().getName());
                     if (paramName != null && Boolean.TRUE.equals(value)) {
                         paramConsumer.accept(paramName);
                     }


### PR DESCRIPTION
Hi, we recently started using `quarkus-cxf` and I noticed some repeated logs during the wsdl2java build step that look like `bool true java.lang.Boolean` or `bool false java.lang.Boolean`. I tracked it down to here, which looks like a leftover from working on https://github.com/quarkiverse/quarkus-cxf/issues/1007 rather than something which is supposed to still be happening?

Sorry if this isn't the right way to do this, thanks for your work.