### PR TITLE
Expose Vert.x HttpClient connection pool configuration options, fix #1853

### DIFF
--- a/docs/modules/ROOT/examples/metrics/application.properties
+++ b/docs/modules/ROOT/examples/metrics/application.properties
@@ -32,6 +32,13 @@ quarkus.cxf.client.contextPropagationCalculator.service-interface = org.jboss.ea
 quarkus.cxf.client.contextPropagationCalculator.out-interceptors = #multiplyingAddInterceptor
 quarkus.cxf.client.contextPropagationCalculator.metrics.enabled = false
 
+
+quarkus.cxf.client.vertxCalculator.client-endpoint-url = ${cxf.it.calculator.baseUri}/calculator-ws/CalculatorService
+quarkus.cxf.client.vertxCalculator.service-interface = org.jboss.eap.quickstarts.wscalculator.calculator.CalculatorService
+quarkus.cxf.client.vertxCalculator.http-conduit-factory = VertxHttpClientHTTPConduitFactory
+quarkus.cxf.client.vertxCalculator.metrics.enabled = true
+quarkus.cxf.client.vertxCalculator.vertx.connection-pool.http1-max-size = 9
+
 # tag::async-client.wsdl2java[]
 quarkus.cxf.codegen.wsdl2java.includes = wsdl/*.wsdl
 quarkus.cxf.codegen.wsdl2java.bindings = src/main/resources/wsdl/async-binding.xml

--- a/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf.adoc
@@ -2319,6 +2319,56 @@ enforced unless it is enabled by other means, such as `@org.apache.cxf.annotatio
 
 *Environment variable*: `+++QUARKUS_CXF_CLIENT__CLIENT_NAME__SCHEMA_VALIDATION_ENABLED_FOR+++` +
 *Since Quarkus CXF*: 2.7.0
+
+.<| [[quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-http1-max-size]]`link:#quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-http1-max-size[quarkus.cxf.client."client-name".vertx.connection-pool.http1-max-size]`
+.<| `int`
+.<| `5`
+
+3+a|The maximum pool size for HTTP/1.x connections.
+
+*Environment variable*: `+++QUARKUS_CXF_CLIENT__CLIENT_NAME__VERTX_CONNECTION_POOL_HTTP1_MAX_SIZE+++` +
+*Since Quarkus CXF*: 3.25.0
+
+.<| [[quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-http2-max-size]]`link:#quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-http2-max-size[quarkus.cxf.client."client-name".vertx.connection-pool.http2-max-size]`
+.<| `int`
+.<| `1`
+
+3+a|The maximum pool size for HTTP/2 connections.
+
+*Environment variable*: `+++QUARKUS_CXF_CLIENT__CLIENT_NAME__VERTX_CONNECTION_POOL_HTTP2_MAX_SIZE+++` +
+*Since Quarkus CXF*: 3.25.0
+
+.<| [[quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-cleaner-period]]`link:#quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-cleaner-period[quarkus.cxf.client."client-name".vertx.connection-pool.cleaner-period]`
+.<| link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[`Duration`] link:#duration-note-anchor-quarkus-cxf[icon:question-circle[title=More information about the Duration format]]
+.<| `1S`
+
+3+a|The connection pool cleaner period.
+A non positive value disables expiration checks and connections will remain in the pool until they are closed.
+
+*Environment variable*: `+++QUARKUS_CXF_CLIENT__CLIENT_NAME__VERTX_CONNECTION_POOL_CLEANER_PERIOD+++` +
+*Since Quarkus CXF*: 3.25.0
+
+.<| [[quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-event-loop-size]]`link:#quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-event-loop-size[quarkus.cxf.client."client-name".vertx.connection-pool.event-loop-size]`
+.<| `int`
+.<| `0`
+
+3+a|The maximum number of event loops this client will create internally.
+The default value `0` will instruct the client not to create any new event loops
+but rather reuse the event loop associated with the caller.
+
+*Environment variable*: `+++QUARKUS_CXF_CLIENT__CLIENT_NAME__VERTX_CONNECTION_POOL_EVENT_LOOP_SIZE+++` +
+*Since Quarkus CXF*: 3.25.0
+
+.<| [[quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-max-wait-queue-size]]`link:#quarkus-cxf_quarkus-cxf-client-client-name-vertx-connection-pool-max-wait-queue-size[quarkus.cxf.client."client-name".vertx.connection-pool.max-wait-queue-size]`
+.<| `int`
+.<| `-1`
+
+3+a|The maximum requests allowed in the wait queue.
+Any requests beyond the max size will result in a `io.vertx.core.http.ConnectionPoolTooBusyException`.
+If the value is negative then the queue is unbounded.
+
+*Environment variable*: `+++QUARKUS_CXF_CLIENT__CLIENT_NAME__VERTX_CONNECTION_POOL_MAX_WAIT_QUEUE_SIZE+++` +
+*Since Quarkus CXF*: 3.25.0
 |===
 
 [NOTE]

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/quarkus/vertx/http/client/deployment/HttpClientCustomizerBuildItem.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/quarkus/vertx/http/client/deployment/HttpClientCustomizerBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.cxf.quarkus.vertx.http.client.deployment;
+
+import java.util.function.BiConsumer;
+
+import io.quarkiverse.cxf.CXFClientInfo;
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+import io.vertx.core.http.HttpClientOptions;
+
+/**
+ */
+public final class HttpClientCustomizerBuildItem extends MultiBuildItem {
+
+    private final RuntimeValue<BiConsumer<CXFClientInfo, HttpClientOptions>> customizer;
+
+    public HttpClientCustomizerBuildItem(RuntimeValue<BiConsumer<CXFClientInfo, HttpClientOptions>> customizer) {
+        super();
+        this.customizer = customizer;
+    }
+
+    public RuntimeValue<BiConsumer<CXFClientInfo, HttpClientOptions>> getCustomizer() {
+        return customizer;
+    }
+}

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/quarkus/vertx/http/client/deployment/VertxWebClientProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/quarkus/vertx/http/client/deployment/VertxWebClientProcessor.java
@@ -1,15 +1,30 @@
 package io.quarkiverse.cxf.quarkus.vertx.http.client.deployment;
 
+import java.util.List;
+
 import io.quarkiverse.cxf.vertx.http.client.HttpClientPool;
+import io.quarkiverse.cxf.vertx.http.client.HttpClientPool.HttpClientPoolRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 
 public class VertxWebClientProcessor {
 
     @BuildStep
     void additionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(HttpClientPool.class));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void httpClientCustomizers(
+            HttpClientPoolRecorder recorder,
+            List<HttpClientCustomizerBuildItem> httpClientCustomizers) {
+        for (HttpClientCustomizerBuildItem customizer : httpClientCustomizers) {
+            recorder.addHttpClientCustomizer(customizer.getCustomizer());
+        }
     }
 
 }

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CXFClientInfo.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CXFClientInfo.java
@@ -12,6 +12,7 @@ import org.apache.cxf.transports.http.configuration.ConnectionType;
 import org.apache.cxf.transports.http.configuration.ProxyServerType;
 
 import io.quarkiverse.cxf.CxfClientConfig.Auth;
+import io.quarkiverse.cxf.CxfClientConfig.VertxConfig;
 import io.quarkiverse.cxf.CxfConfig.CxfGlobalClientConfig;
 import io.quarkiverse.cxf.CxfConfig.RetransmitCacheConfig;
 import io.quarkus.arc.Arc;
@@ -41,6 +42,7 @@ public class CXFClientInfo {
     private final String epNamespace;
     private final String epName;
     private final Auth auth;
+    private final VertxConfig vertxConfig;
     private final boolean proxyClassRuntimeInitialized;
     private final List<String> inInterceptors = new ArrayList<>();
     private final List<String> outInterceptors = new ArrayList<>();
@@ -231,6 +233,7 @@ public class CXFClientInfo {
         this.epNamespace = config.endpointNamespace().orElse(null);
         this.epName = config.endpointName().orElse(null);
         this.auth = new AuthWrapper(config.auth(), config);
+        this.vertxConfig = config.vertx();
         this.secureWsdlAccess = config.secureWsdlAccess();
         this.endpointAddress = config.clientEndpointUrl().orElse(DEFAULT_EP_ADDR + "/" + this.sei.toLowerCase());
         this.wsdlUrl = config.wsdlPath().orElse(null);
@@ -427,6 +430,10 @@ public class CXFClientInfo {
 
     public Auth getAuth() {
         return auth;
+    }
+
+    public VertxConfig getVertxConfig() {
+        return vertxConfig;
     }
 
     public boolean isProxyClassRuntimeInitialized() {

--- a/extensions/features-metrics/deployment/src/main/java/io/quarkiverse/cxf/metrics/deployment/QuarkusCxfMetricsProcessor.java
+++ b/extensions/features-metrics/deployment/src/main/java/io/quarkiverse/cxf/metrics/deployment/QuarkusCxfMetricsProcessor.java
@@ -5,11 +5,15 @@ import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.metrics.MetricsFeature;
 import org.apache.cxf.metrics.codahale.CodahaleMetricsProvider;
 
+import io.quarkiverse.cxf.metrics.CxfMetricsRecorder;
 import io.quarkiverse.cxf.metrics.MetricsCustomizer;
 import io.quarkiverse.cxf.metrics.QuarkusCxfMetricsFeature;
+import io.quarkiverse.cxf.quarkus.vertx.http.client.deployment.HttpClientCustomizerBuildItem;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
@@ -48,4 +52,13 @@ public class QuarkusCxfMetricsProcessor {
         additionalBeans.produce(
                 new AdditionalBeanBuildItem(MetricsCustomizer.class));
     }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void httpClientCustomizers(
+            CxfMetricsRecorder recorder,
+            BuildProducer<HttpClientCustomizerBuildItem> httpClientCustomizers) {
+        httpClientCustomizers.produce(new HttpClientCustomizerBuildItem(recorder.httpClientCustomizer()));
+    }
+
 }

--- a/extensions/features-metrics/runtime/src/main/java/io/quarkiverse/cxf/metrics/CxfMetricsRecorder.java
+++ b/extensions/features-metrics/runtime/src/main/java/io/quarkiverse/cxf/metrics/CxfMetricsRecorder.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.cxf.metrics;
+
+import java.util.function.BiConsumer;
+
+import io.quarkiverse.cxf.CXFClientInfo;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.http.HttpClientOptions;
+
+/**
+ * @since 2.25.0
+ */
+@Recorder
+public class CxfMetricsRecorder {
+    public RuntimeValue<BiConsumer<CXFClientInfo, HttpClientOptions>> httpClientCustomizer() {
+        return new RuntimeValue<BiConsumer<CXFClientInfo, HttpClientOptions>>(
+                (clientInfo, opts) -> {
+                    opts.setMetricsName("cxf|" + clientInfo.getConfigKey());
+                });
+    }
+}

--- a/integration-tests/metrics/src/main/java/io/quarkiverse/cxf/metrics/client/it/VertxHttpClientResource.java
+++ b/integration-tests/metrics/src/main/java/io/quarkiverse/cxf/metrics/client/it/VertxHttpClientResource.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.cxf.metrics.client.it;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.eap.quickstarts.wscalculator.calculator.AddResponse;
+import org.jboss.eap.quickstarts.wscalculator.calculator.CalculatorService;
+
+import io.quarkiverse.cxf.annotation.CXFClient;
+import io.quarkiverse.cxf.mutiny.CxfMutinyUtils;
+import io.smallrye.mutiny.Uni;
+
+@Path("/VertxHttpClientResource")
+public class VertxHttpClientResource {
+
+    @Inject
+    @CXFClient("vertxCalculator")
+    CalculatorService vertxCalculator;
+
+    @SuppressWarnings("unchecked")
+    @Path("/addAsync")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Integer> addAsync(@QueryParam("a") int a, @QueryParam("b") int b) {
+        return CxfMutinyUtils
+                .<AddResponse> toUni(handler -> vertxCalculator.addAsync(a, b, handler))
+                .map(AddResponse::getReturn);
+    }
+}

--- a/integration-tests/metrics/src/main/resources/application.properties
+++ b/integration-tests/metrics/src/main/resources/application.properties
@@ -32,6 +32,13 @@ quarkus.cxf.client.contextPropagationCalculator.service-interface = org.jboss.ea
 quarkus.cxf.client.contextPropagationCalculator.out-interceptors = #multiplyingAddInterceptor
 quarkus.cxf.client.contextPropagationCalculator.metrics.enabled = false
 
+
+quarkus.cxf.client.vertxCalculator.client-endpoint-url = ${cxf.it.calculator.baseUri}/calculator-ws/CalculatorService
+quarkus.cxf.client.vertxCalculator.service-interface = org.jboss.eap.quickstarts.wscalculator.calculator.CalculatorService
+quarkus.cxf.client.vertxCalculator.http-conduit-factory = VertxHttpClientHTTPConduitFactory
+quarkus.cxf.client.vertxCalculator.metrics.enabled = true
+quarkus.cxf.client.vertxCalculator.vertx.connection-pool.http1-max-size = 9
+
 # tag::async-client.wsdl2java[]
 quarkus.cxf.codegen.wsdl2java.includes = wsdl/*.wsdl
 quarkus.cxf.codegen.wsdl2java.bindings = src/main/resources/wsdl/async-binding.xml

--- a/integration-tests/metrics/src/test/java/io/quarkiverse/cxf/metrics/it/MetricsTest.java
+++ b/integration-tests/metrics/src/test/java/io/quarkiverse/cxf/metrics/it/MetricsTest.java
@@ -98,6 +98,8 @@ public class MetricsTest {
 
     }
 
+    // TODO test like in     io.quarkus.micrometer.deployment.binder.VertxHttpClientMetricsTest
+
     public static Map<String, Object> getMetrics() {
         final String body = RestAssured.given()
                 .header("Content-Type", "application/json")

--- a/integration-tests/metrics/src/test/java/io/quarkiverse/cxf/metrics/it/VertxHttpClientMetricsTest.java
+++ b/integration-tests/metrics/src/test/java/io/quarkiverse/cxf/metrics/it/VertxHttpClientMetricsTest.java
@@ -1,0 +1,82 @@
+package io.quarkiverse.cxf.metrics.it;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.assertj.core.api.Assertions;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+
+@QuarkusTest
+public class VertxHttpClientMetricsTest {
+    private static final int WORKERS_COUNT = 128;
+    private static final int ITERATIONS_COUNT = 4;
+
+    @Test
+    void vertxHttpClient() throws InterruptedException, ExecutionException {
+
+        /* There should be no Vert.x HttpClient connection pool metrics available before we call anything */
+        Assertions.assertThat(getMetrics().get("http.client.active.connections;clientName=vertxCalculator")).isNull();
+
+        /*
+         * Produce some concurrent load so that the client is forced to open as many connections as we allowed in
+         * quarkus.cxf.client.vertxCalculator.vertx.connection-pool.http1-max-size
+         */
+        final ExecutorService executor = Executors.newFixedThreadPool(WORKERS_COUNT);
+        final List<Future<Void>> futures = new ArrayList<>(WORKERS_COUNT);
+        try {
+
+            for (int i = 0; i < WORKERS_COUNT; i++) {
+                final Future<Void> f = executor.submit(() -> {
+                    for (int j = 0; j < ITERATIONS_COUNT; j++) {
+                        RestAssured.given()
+                                .queryParam("a", 7)
+                                .queryParam("b", 4)
+                                .get("/VertxHttpClientResource/addAsync")
+                                .then()
+                                .statusCode(200)
+                                .body(Matchers.is("11"));
+
+                    }
+                    return null;
+                });
+                futures.add(f);
+            }
+
+            // Ensure all tasks are completed
+            for (Future<Void> future : futures) {
+                future.get();
+            }
+        } finally {
+            executor.shutdown();
+        }
+        //System.out.println(getMetrics());
+        /*
+         * Finally make sure the metric shows the value we have set in
+         * quarkus.cxf.client.vertxCalculator.vertx.connection-pool.http1-max-size
+         */
+        Assertions.assertThat(getMetrics().get("http.client.active.connections;clientName=vertxCalculator"))
+                .isEqualTo(9.0f);
+    }
+
+    public static Map<String, Object> getMetrics() {
+        final String body = RestAssured.given()
+                .header("Content-Type", "application/json")
+                .get("/q/metrics/json")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+        final JsonPath jp = new JsonPath(body);
+        return jp.getJsonObject("$");
+    }
+
+}


### PR DESCRIPTION
fix #1853

Out of the new options, only the `quarkus.cxf.client."client-name".vertx.connection-pool.http1-max-size` option is tested. It is done through exposing the Vert.x HttpClient metrics (a bonus feature I had to implement in `quarkus-cxf-rt-features-metrics`) and checking that `http.client.active.connections;clientName=client-name` gauge has the appropriate value after producing some load.

cc @Tomnivore, @doppiak
