### PR TITLE
[3.20] Increase the overall timeout for Antora link validation to 5 mins

### DIFF
--- a/docs/src/test/java/io/quarkiverse/cxf/doc/it/AntoraTest.java
+++ b/docs/src/test/java/io/quarkiverse/cxf/doc/it/AntoraTest.java
@@ -51,7 +51,7 @@ public class AntoraTest {
                 .links()
                 .excludeResolved(Pattern.compile("^\\Qhttp://localhost:808\\E[02].*"))
                 .excludeEditThisPage()
-                .overallTimeout(120_000L);
+                .overallTimeout(300_000L); // 5 min
 
         final String ghToken = System.getenv("GITHUB_TOKEN");
         if (ghToken == null) {


### PR DESCRIPTION
… so that we can make some retries even if some connect attempts timeout after 30 seconds