### PR TITLE
Missing runtime config wrongly reported as build time: IllegalStateException: quarkus.cxf.client.Service is referenced in xxx.Service Service but no such build time configuration entry exists

### DIFF
--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfClientProducer.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfClientProducer.java
@@ -283,8 +283,8 @@ public abstract class CxfClientProducer {
                 meta,
                 configKey,
                 () -> new IllegalStateException(
-                        "quarkus.cxf.client.\"" + configKey + "\" is referenced in " + ip.getMember()
-                                + " but no such build time configuration entry exists"),
+                        "@" + CXFClient.class.getName() + "(\"" + configKey + "\") is present on " + ip.getMember()
+                                + " but quarkus.cxf.client.\"" + configKey + "\".* configuration is missing"),
                 vertx);
     }
 


### PR DESCRIPTION
fix #1964