### PR TITLE
[Ciphersuites] Fix root cause message on windows

### DIFF
--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CipherSuitesTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CipherSuitesTest.java
@@ -124,7 +124,7 @@ public class CipherSuitesTest {
 
         HelloService clientFake = client(clientName + "Fake");
 
-        Assertions.assertThatThrownBy(() -> clientFake.hello("Doe")).hasRootCauseMessage(
+        Assertions.assertThatThrownBy(() -> clientFake.hello("Doe")).rootCause().message().contains(
                 "Received fatal alert: handshake_failure");
 
         HelloService clientExisting = client(clientName + "Existing");


### PR DESCRIPTION
when running on windows 2022, the test failed as the message was slightly different:

```
Expecting a root cause with message:
  "Received fatal alert: handshake_failure"
but message was:
  "(handshake_failure) Received fatal alert: handshake_failure".
```
