### PR TITLE
Register sun.security.util.resources.security in native mode 

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -589,6 +589,10 @@ class QuarkusCxfProcessor {
         IndexView index = combinedIndexBuildItem.getIndex();
         DotName rootPackage = DotName.createSimple("org.apache.cxf");
         registerMessages(index, Thread.currentThread().getContextClassLoader(), rootPackage, resources);
+
+        Stream.of("sun.security.util.resources.security")
+                .map(NativeImageResourceBundleBuildItem::new)
+                .forEach(resources::produce);
     }
 
     static void registerMessages(


### PR DESCRIPTION
... so that any potential failures in javax.security.auth API do not fail with java.util.MissingResourceException: Can't find bundle for base name sun.security.util.resources.security; such failures are reproducible with Camel Quarkus - see https://github.com/apache/camel-quarkus/issues/8148