### PR TITLE
Prevent 'Prometheus requires that all meters with the same name have the same set of tag keys' error by using the same set of tags everywhere

### DIFF
--- a/integration-tests/metrics/src/main/java/io/quarkiverse/cxf/metrics/it/async/HeaderToMetricsTagsCustomizer.java
+++ b/integration-tests/metrics/src/main/java/io/quarkiverse/cxf/metrics/it/async/HeaderToMetricsTagsCustomizer.java
@@ -24,6 +24,6 @@ public class HeaderToMetricsTagsCustomizer implements TagsCustomizer {
         if (val != null) {
             return Tags.of(Tag.of("my-header", val));
         }
-        return Tags.empty();
+        return Tags.of(Tag.of("my-header", "<empty>"));
     }
 }

--- a/integration-tests/metrics/src/test/java/io/quarkiverse/cxf/metrics/it/MetricsTest.java
+++ b/integration-tests/metrics/src/test/java/io/quarkiverse/cxf/metrics/it/MetricsTest.java
@@ -53,10 +53,10 @@ public class MetricsTest {
             Map<String, Object> serverRequests = (Map<String, Object>) metrics.get("cxf.server.requests");
             Assertions.assertThat(serverRequests).isNotNull();
             Assertions.assertThat(serverRequests.get(
-                    "count;exception=None;faultCode=None;method=POST;operation=hello;outcome=SUCCESS;status=200;uri=/soap/hello"))
+                    "count;exception=None;faultCode=None;method=POST;my-header=<empty>;operation=hello;outcome=SUCCESS;status=200;uri=/soap/hello"))
                     .isEqualTo(1);
             Assertions.assertThat((Float) serverRequests.get(
-                    "elapsedTime;exception=None;faultCode=None;method=POST;operation=hello;outcome=SUCCESS;status=200;uri=/soap/hello"))
+                    "elapsedTime;exception=None;faultCode=None;method=POST;my-header=<empty>;operation=hello;outcome=SUCCESS;status=200;uri=/soap/hello"))
                     .isGreaterThan(0.0F);
         }
 
@@ -77,20 +77,20 @@ public class MetricsTest {
             Map<String, Object> serverRequests = (Map<String, Object>) metrics.get("cxf.server.requests");
             Assertions.assertThat(serverRequests).isNotNull();
             Assertions.assertThat(serverRequests.get(
-                    "count;exception=None;faultCode=None;method=POST;operation=hello;outcome=SUCCESS;status=200;uri=/soap/hello"))
+                    "count;exception=None;faultCode=None;method=POST;my-header=<empty>;operation=hello;outcome=SUCCESS;status=200;uri=/soap/hello"))
                     .isEqualTo(2);
             Assertions.assertThat((Float) serverRequests.get(
-                    "elapsedTime;exception=None;faultCode=None;method=POST;operation=hello;outcome=SUCCESS;status=200;uri=/soap/hello"))
+                    "elapsedTime;exception=None;faultCode=None;method=POST;my-header=<empty>;operation=hello;outcome=SUCCESS;status=200;uri=/soap/hello"))
                     .isGreaterThan(0.0F);
 
             Map<String, Object> clientRequests = (Map<String, Object>) metrics.get("cxf.client.requests");
             Assertions.assertThat(clientRequests).isNotNull();
             Assertions.assertThat(clientRequests.get(
-                    "count;exception=None;faultCode=None;method=POST;operation=hello;outcome=SUCCESS;status=200;uri=http://localhost:"
+                    "count;exception=None;faultCode=None;method=POST;my-header=<empty>;operation=hello;outcome=SUCCESS;status=200;uri=http://localhost:"
                             + port + "/soap/hello"))
                     .isEqualTo(1);
             Assertions.assertThat((Float) clientRequests.get(
-                    "elapsedTime;exception=None;faultCode=None;method=POST;operation=hello;outcome=SUCCESS;status=200;uri=http://localhost:"
+                    "elapsedTime;exception=None;faultCode=None;method=POST;my-header=<empty>;operation=hello;outcome=SUCCESS;status=200;uri=http://localhost:"
                             + port + "/soap/hello"))
                     .isGreaterThan(0.0F);
 

--- a/integration-tests/metrics/src/test/java/io/quarkiverse/cxf/metrics/it/async/AsyncClientTest.java
+++ b/integration-tests/metrics/src/test/java/io/quarkiverse/cxf/metrics/it/async/AsyncClientTest.java
@@ -44,8 +44,16 @@ class AsyncClientTest {
 
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "sync-observable", "async-observable" })
+    @Test
+    void addObservableSync() {
+        addObservable("sync-observable");
+    }
+
+    @Test
+    void addObservableAsync() {
+        addObservable("async-observable");
+    }
+
     void addObservable(String syncMode) {
 
         if (syncMode.contains("async")) {


### PR DESCRIPTION
Solves an issue occurring with current Quarkus main branch (at 3779c237c3bcca306131fcae27f9d6bfacf705a2 )