### PR TITLE
Log non-loadable CXF Bus extensions at debug level, because it is normal

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -327,7 +327,7 @@ class QuarkusCxfProcessor {
             Class.forName(className, true, Thread.currentThread().getContextClassLoader());
             return true;
         } catch (ClassNotFoundException | NoClassDefFoundError e) {
-            LOGGER.warnf(e, "Ignoring non-loadable CXF Bus extension %s from %s", className, url);
+            LOGGER.debugf(e, "Ignoring non-loadable CXF Bus extension %s from %s", className, url);
         }
         return false;
     }

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/mutiny/CxfMutinyUtils.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/mutiny/CxfMutinyUtils.java
@@ -87,7 +87,7 @@ public class CxfMutinyUtils {
                             .workerDispatchTimeout();
                     final Vertx vertx = container.instance(Vertx.class).get();
 
-                    final Runnable cancelTimer;
+                    final CancelTimer cancelTimer;
                     if (workerDispatchTimeout > 0) {
                         final long timerId = vertx.setTimer(workerDispatchTimeout, id -> {
                             boolean shouldTimeout = !terminated.getAndSet(true);
@@ -122,7 +122,7 @@ public class CxfMutinyUtils {
             }
         }
 
-        private void subscribeIntenal(UniSubscriber<? super T> downstream, AtomicBoolean terminated, Runnable cancelTimer) {
+        private void subscribeIntenal(UniSubscriber<? super T> downstream, AtomicBoolean terminated, CancelTimer cancelTimer) {
             try {
                 subscriptionConsumer.accept(response -> {
                     if (cancelTimer != null) {
@@ -130,7 +130,7 @@ public class CxfMutinyUtils {
                     }
                     boolean alive = !terminated.getAndSet(true);
                     if (log.isDebugEnabled()) {
-                        log.debugf("Scheduled on a worker thread for timer %d: %s", cancelTimer, alive ? "alive" : "dead");
+                        log.debugf("Scheduled on a worker thread for timer %s: %s", cancelTimer, alive ? "alive" : "dead");
                     }
                     if (alive) {
                         try {


### PR DESCRIPTION
that they occur.