### PR TITLE
[3.33] Log non-loadable CXF Bus extensions at debug level, because it is normal

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -327,7 +327,7 @@ class QuarkusCxfProcessor {
             Class.forName(className, true, Thread.currentThread().getContextClassLoader());
             return true;
         } catch (ClassNotFoundException | NoClassDefFoundError e) {
-            LOGGER.warnf(e, "Ignoring non-loadable CXF Bus extension %s from %s", className, url);
+            LOGGER.debugf(e, "Ignoring non-loadable CXF Bus extension %s from %s", className, url);
         }
         return false;
     }


### PR DESCRIPTION
that they occur.