### PR TITLE
[3.33] Log CancelTimer as a string to avoid java.util.IllegalFormatConversionException: d != io.quarkiverse.cxf.mutiny.CxfMutinyUtils

### DIFF
--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/mutiny/CxfMutinyUtils.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/mutiny/CxfMutinyUtils.java
@@ -87,7 +87,7 @@ public class CxfMutinyUtils {
                             .workerDispatchTimeout();
                     final Vertx vertx = container.instance(Vertx.class).get();
 
-                    final Runnable cancelTimer;
+                    final CancelTimer cancelTimer;
                     if (workerDispatchTimeout > 0) {
                         final long timerId = vertx.setTimer(workerDispatchTimeout, id -> {
                             boolean shouldTimeout = !terminated.getAndSet(true);
@@ -122,7 +122,7 @@ public class CxfMutinyUtils {
             }
         }
 
-        private void subscribeIntenal(UniSubscriber<? super T> downstream, AtomicBoolean terminated, Runnable cancelTimer) {
+        private void subscribeIntenal(UniSubscriber<? super T> downstream, AtomicBoolean terminated, CancelTimer cancelTimer) {
             try {
                 subscriptionConsumer.accept(response -> {
                     if (cancelTimer != null) {
@@ -130,7 +130,7 @@ public class CxfMutinyUtils {
                     }
                     boolean alive = !terminated.getAndSet(true);
                     if (log.isDebugEnabled()) {
-                        log.debugf("Scheduled on a worker thread for timer %d: %s", cancelTimer, alive ? "alive" : "dead");
+                        log.debugf("Scheduled on a worker thread for timer %s: %s", cancelTimer, alive ? "alive" : "dead");
                     }
                     if (alive) {
                         try {


### PR DESCRIPTION
Here is the whole stack trace: 

```
LogManager error of type FORMAT_FAILURE: Formatting error
java.util.IllegalFormatConversionException: d != io.quarkiverse.cxf.mutiny.CxfMutinyUtils$CancelTimer
	at java.base/java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4442)
	at java.base/java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:2963)
	at java.base/java.util.Formatter$FormatSpecifier.print(Formatter.java:2918)
	at java.base/java.util.Formatter.format(Formatter.java:2689)
	at java.base/java.util.Formatter.format(Formatter.java:2625)
	at java.base/java.lang.String.format(String.java:4145)
	at org.jboss.logmanager.ExtFormatter.formatMessagePrintf(ExtFormatter.java:144)
	at org.jboss.logmanager.ExtFormatter.formatMessage(ExtFormatter.java:91)
	at org.jboss.logmanager.formatters.Formatters$16.renderRaw(Formatters.java:832)
	at org.jboss.logmanager.formatters.Formatters$JustifyingFormatStep.render(Formatters.java:227)
	at org.jboss.logmanager.formatters.MultistepFormatter.format(MultistepFormatter.java:90)
	at org.jboss.logmanager.ExtFormatter.format(ExtFormatter.java:58)
	at org.jboss.logmanager.handlers.WriterHandler.doPublish(WriterHandler.java:58)
	at org.jboss.logmanager.ExtHandler.publish(ExtHandler.java:88)
	at org.jboss.logmanager.ExtHandler.publishToNestedHandlers(ExtHandler.java:125)
	at io.quarkus.bootstrap.logging.QuarkusDelayedHandler.doPublish(QuarkusDelayedHandler.java:81)
	at org.jboss.logmanager.ExtHandler.publish(ExtHandler.java:88)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:437)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:479)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:479)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:479)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:479)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:479)
	at org.jboss.logmanager.Logger.logRaw(Logger.java:921)
	at org.jboss.logmanager.Logger.log(Logger.java:884)
	at org.jboss.logging.JBossLogManagerLogger.doLogf(JBossLogManagerLogger.java:56)
	at org.jboss.logging.Logger.debugf(Logger.java:727)
	at io.quarkiverse.cxf.mutiny.CxfMutinyUtils$WsAsyncHandlerUni.lambda$subscribeIntenal$4(CxfMutinyUtils.java:133)
	at org.apache.cxf.jaxws.JaxwsClientCallback.handleResponse(JaxwsClientCallback.java:44)
	at org.apache.cxf.endpoint.ClientImpl.onMessage(ClientImpl.java:949)
	at io.quarkiverse.cxf.vertx.http.client.VertxHttpClientHTTPConduit$ResponseHandler.handle(VertxHttpClientHTTPConduit.java:1472)
	at io.quarkiverse.cxf.vertx.http.client.VertxHttpClientHTTPConduit$ResponseHandler.handle(VertxHttpClientHTTPConduit.java:1381)
	at io.quarkiverse.cxf.vertx.http.client.VertxHttpClientHTTPConduit$RequestBodyHandler$Mode$Async.lambda$responseReady$0(VertxHttpClientHTTPConduit.java:1245)
	at io.smallrye.context.impl.wrappers.SlowContextualRunnable.run(SlowContextualRunnable.java:19)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$15.runWith(VertxCoreRecorder.java:677)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2651)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2630)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1694)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1589)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:11)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:11)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
2026-04-14 16:43:35,498 WARN  [org.apache.cxf.phase.PhaseInterceptorChain] (executor-thread-4) Interceptor for {http://client.test.deployment.cxf.quarkiverse.io/}HelloService has thrown exception, unwinding now: java.lang.RuntimeException: Couldn't parse stream.
	at org.apache.cxf.staxutils.StaxUtils.createXMLStreamReader(StaxUtils.java:1715)
	at org.apache.cxf.interceptor.StaxInInterceptor.handleMessage(StaxInInterceptor.java:129)
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307)
	at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121)
	at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:267)
	at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:233)
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:207)
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:159)
	at io.quarkiverse.cxf.transport.CxfHandler.process(CxfHandler.java:212)
	at io.quarkiverse.cxf.transport.CxfHandler.handle(CxfHandler.java:183)
	at io.quarkiverse.cxf.transport.CxfHandler.handle(CxfHandler.java:48)
	at io.vertx.ext.web.impl.BlockingHandlerDecorator.lambda$handle$0(BlockingHandlerDecorator.java:48)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$5(ContextImpl.java:205)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
	at io.vertx.core.impl.ContextImpl$1.execute(ContextImpl.java:221)
	at io.vertx.core.impl.WorkerTask.run(WorkerTask.java:56)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$15.runWith(VertxCoreRecorder.java:677)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2651)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2630)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1694)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1589)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:11)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:11)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: com.ctc.wstx.exc.WstxIOException: java.nio.channels.ClosedChannelException
	at com.ctc.wstx.stax.WstxInputFactory.doCreateSR(WstxInputFactory.java:580)
	at com.ctc.wstx.stax.WstxInputFactory.createSR(WstxInputFactory.java:635)
	at com.ctc.wstx.stax.WstxInputFactory.createSR(WstxInputFactory.java:659)
	at com.ctc.wstx.stax.WstxInputFactory.createXMLStreamReader(WstxInputFactory.java:344)
	at org.apache.cxf.staxutils.StaxUtils.createXMLStreamReader(StaxUtils.java:1713)
	... 24 more
Caused by: java.io.IOException: java.nio.channels.ClosedChannelException
	at io.quarkus.vertx.http.runtime.VertxInputStream$VertxBlockingInput.readBlocking(VertxInputStream.java:255)
	at io.quarkus.vertx.http.runtime.VertxInputStream.readIntoBuffer(VertxInputStream.java:122)
	at io.quarkus.vertx.http.runtime.VertxInputStream.read(VertxInputStream.java:84)
	at io.quarkiverse.cxf.transport.VertxHttpServletRequest$1.read(VertxHttpServletRequest.java:144)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:132)
	at com.ctc.wstx.io.BaseReader.readBytes(BaseReader.java:155)
	at com.ctc.wstx.io.UTF8Reader.loadMore(UTF8Reader.java:369)
	at com.ctc.wstx.io.UTF8Reader.read(UTF8Reader.java:116)
	at com.ctc.wstx.io.ReaderBootstrapper.initialLoad(ReaderBootstrapper.java:254)
	at com.ctc.wstx.io.ReaderBootstrapper.bootstrapInput(ReaderBootstrapper.java:134)
	at com.ctc.wstx.stax.WstxInputFactory.doCreateSR(WstxInputFactory.java:575)
	... 28 more
Caused by: java.nio.channels.ClosedChannelException
	at io.quarkus.vertx.http.runtime.VertxInputStream$VertxBlockingInput.<init>(VertxInputStream.java:183)
	at io.quarkus.vertx.http.runtime.VertxInputStream.<init>(VertxInputStream.java:36)
	at io.quarkiverse.cxf.transport.VertxHttpServletRequest.<init>(VertxHttpServletRequest.java:67)
	at io.quarkiverse.cxf.transport.CxfHandler.process(CxfHandler.java:210)
	... 16 more
```