### PR TITLE
Eliminate Quarkus Regression ConfigProvider.getConfig().getValue("quarkus.http.port", Integer.class) does not work in BeforeAll methods 

### DIFF
--- a/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/client/WorkerDispatchTimeoutTest.java
+++ b/extensions/core/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/client/WorkerDispatchTimeoutTest.java
@@ -16,6 +16,7 @@ import jakarta.xml.ws.Response;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.vertx.core.Vertx;
 
 public class WorkerDispatchTimeoutTest {
+    private static final Logger log = Logger.getLogger(WorkerDispatchTimeoutTest.class);
 
     private static final int MAX_THREADS = 4;
 
@@ -44,6 +46,13 @@ public class WorkerDispatchTimeoutTest {
             .overrideConfigKey("quarkus.thread-pool.max-threads", String.valueOf(MAX_THREADS))
             .overrideConfigKey("quarkus.log.category.\"io.quarkiverse.cxf.QuarkusJaxWsProxyFactoryBean\".level", "DEBUG")
             .overrideConfigKey("quarkus.log.category.\"io.quarkiverse.cxf.mutiny.CxfMutinyUtils\".level", "DEBUG")
+            /*
+             * Avoid too many warnings about uncaught exceptions due to requests being processed after shut down - that's
+             * expected
+             */
+            .overrideConfigKey("quarkus.log.category.\"org.jboss.threads.errors\".level", "FATAL")
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.vertx.core.runtime.VertxCoreRecorder\".level", "FATAL")
+            .overrideConfigKey("quarkus.log.category.\"org.apache.cxf.phase.PhaseInterceptorChain\".level", "ERROR")
 
             .overrideConfigKey("quarkus.cxf.endpoint.\"/hello\".implementor", HelloServiceImpl.class.getName())
             .overrideConfigKey("quarkus.cxf.client.hello.client-endpoint-url", "http://localhost:8081/services/hello")
@@ -68,17 +77,19 @@ public class WorkerDispatchTimeoutTest {
         final int maxCnt = 200;
         /* Submit more and more requests till some of them timeouts due to worker thread pool exhaustion */
         while (cnt++ <= maxCnt && firstException.get() == null) {
+            final String currentCnt = String.valueOf(cnt - 1);
             vertx.runOnContext(v -> {
                 if (firstException.get() == null) {
-                    Future<?> fut = hello.helloAsync(DELAY, resp -> {
+                    Future<?> fut = hello.helloAsync(currentCnt, resp -> {
                         firstException.updateAndGet(oldValue -> {
                             if (oldValue != null) {
                                 return oldValue;
                             }
                             try {
-                                resp.get().getReturn();
+                                log.infof("Normal response for request %s: %s", currentCnt, resp.get().getReturn());
                                 return null;
                             } catch (Exception e) {
+                                log.infof("Exception response for request %s: %s", currentCnt, e);
                                 return e;
                             }
                         });
@@ -90,6 +101,7 @@ public class WorkerDispatchTimeoutTest {
                 }
             });
         }
+        log.infof("Sent %d requests", cnt);
         Awaitility.waitAtMost(10, TimeUnit.SECONDS).until(() -> firstException.get() != null);
 
         Assertions.assertThat(firstException.get())
@@ -175,7 +187,7 @@ public class WorkerDispatchTimeoutTest {
                 throw new RuntimeException("Expected exception");
             }
             try {
-                long delay = Long.parseLong(person);
+                long delay = Long.parseLong(DELAY);
                 try {
                     Thread.sleep(delay);
                 } catch (InterruptedException e) {

--- a/integration-tests/server/src/test/java/io/quarkiverse/cxf/it/server/AbstractGreetingWebServiceTest.java
+++ b/integration-tests/server/src/test/java/io/quarkiverse/cxf/it/server/AbstractGreetingWebServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.cxf.test.QuarkusCxfTestUtil;
 
 abstract class AbstractGreetingWebServiceTest {
-    protected static GreetingWebService greetingWS;
+    protected GreetingWebService greetingWS;
     static final String SOAP_REQUEST = "<x:Envelope xmlns:x=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:cxf=\"http://server.it.cxf.quarkiverse.io/\">\n"
             +
             "   <x:Header/>\n" +

--- a/integration-tests/server/src/test/java/io/quarkiverse/cxf/it/server/GreetingWebServiceImplTest.java
+++ b/integration-tests/server/src/test/java/io/quarkiverse/cxf/it/server/GreetingWebServiceImplTest.java
@@ -1,7 +1,7 @@
 package io.quarkiverse.cxf.it.server;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.cxf.test.QuarkusCxfTestUtil;
@@ -10,8 +10,8 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 public class GreetingWebServiceImplTest extends AbstractGreetingWebServiceTest {
 
-    @BeforeAll
-    static void setup() {
+    @BeforeEach
+    void setup() {
         greetingWS = QuarkusCxfTestUtil.getClient(GreetingWebService.class, "/soap/greeting");
     }
 

--- a/integration-tests/server/src/test/java/io/quarkiverse/cxf/it/server/GreetingWebServiceNoIntfTest.java
+++ b/integration-tests/server/src/test/java/io/quarkiverse/cxf/it/server/GreetingWebServiceNoIntfTest.java
@@ -3,7 +3,7 @@ package io.quarkiverse.cxf.it.server;
 import jakarta.jws.WebService;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.cxf.test.QuarkusCxfTestUtil;
@@ -12,8 +12,8 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 class GreetingWebServiceNoIntfTest extends AbstractGreetingWebServiceTest {
 
-    @BeforeAll
-    static void setup() {
+    @BeforeEach
+    void setup() {
         greetingWS = QuarkusCxfTestUtil.getClient(GreetingWebServiceNoIntf.class, "/soap/greeting-no-intf");
     }
 

--- a/test-util-parent/test-util/src/main/java/io/quarkiverse/cxf/test/QuarkusCxfTestUtil.java
+++ b/test-util-parent/test-util/src/main/java/io/quarkiverse/cxf/test/QuarkusCxfTestUtil.java
@@ -9,10 +9,7 @@ import jakarta.jws.WebService;
 import jakarta.xml.ws.BindingProvider;
 import jakarta.xml.ws.Service;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-
-import io.quarkus.runtime.LaunchMode;
 
 /**
  * Test utilities intended for developers implementing applications on top of Quarkus CXF.
@@ -65,9 +62,7 @@ public class QuarkusCxfTestUtil {
      * @since 3.33.0
      */
     public static String getServerUrl() {
-        final Config config = ConfigProvider.getConfig();
-        final int port = LaunchMode.current().equals(LaunchMode.TEST) ? config.getValue("quarkus.http.test-port", Integer.class)
-                : config.getValue("quarkus.http.port", Integer.class);
+        final int port = ConfigProvider.getConfig().getValue("quarkus.http.port", Integer.class);
         return String.format("http://localhost:%d", port);
     }
 


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/53692