### PR TITLE
Forward configurable -D properties to child Maven invocations in DevModeTest

### DIFF
--- a/integration-tests/server/pom.xml
+++ b/integration-tests/server/pom.xml
@@ -63,6 +63,9 @@
                                 <![CDATA[
                                     project.properties.setProperty("qcxf.maven.settings.xml.path", session.request.userSettingsFile.toString())
                                     project.properties.setProperty("qcxf.maven.active.profiles", session.request.activeProfiles.join(","))
+                                    // Pass -Dqcxf.maven.user.properties.prefixes=maven.repo.local,repo. to forward matching -D properties to child Maven invocations
+                                    def prefixes = (project.properties.getProperty("qcxf.maven.user.properties.prefixes") ?: "").split(",")
+                                    project.properties.setProperty("qcxf.maven.user.properties", session.request.userProperties.findAll { k, v -> prefixes.any { p -> k.startsWith(p) } }.collect { k, v -> "-D${k}=${v}" }.join(" "))
                                 ]]>
                             </source>
                         </configuration>
@@ -151,6 +154,7 @@
                         <quarkus-cxf.platform.version>${quarkus-cxf.platform.version}</quarkus-cxf.platform.version>
                         <qcxf.maven.settings.xml.path>${qcxf.maven.settings.xml.path}</qcxf.maven.settings.xml.path>
                         <qcxf.maven.active.profiles>${qcxf.maven.active.profiles}</qcxf.maven.active.profiles>
+                        <qcxf.maven.user.properties>${qcxf.maven.user.properties}</qcxf.maven.user.properties>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/integration-tests/server/src/test/java/io/quarkiverse/cxf/it/server/DevModeTest.java
+++ b/integration-tests/server/src/test/java/io/quarkiverse/cxf/it/server/DevModeTest.java
@@ -37,6 +37,7 @@ public class DevModeTest {
         final Path settingsPath = Path.of(getProperty("qcxf.maven.settings.xml.path")).toAbsolutePath().normalize();
         Assertions.assertThat(settingsPath).isRegularFile();
         final String activeProfiles = System.getProperty("qcxf.maven.active.profiles");
+        final String userProperties = System.getProperty("qcxf.maven.user.properties");
 
         final String quarkusGroupId = getProperty("quarkus.platform.group-id");
         final String quarkusVersion = getProperty("quarkus.platform.version");
@@ -64,7 +65,7 @@ public class DevModeTest {
 
         final Mvn mvn = Mvn.fromMvnw(Path.of(".").toAbsolutePath().normalize()).installIfNeeded();
         mvn
-                .args(args(activeProfiles, settingsPath,
+                .args(args(activeProfiles, settingsPath, userProperties,
                         quarkusPluginGroupId + ":quarkus-maven-plugin:" + quarkusPluginVersion + ":create",
                         "-ntp",
                         "-DprojectGroupId=io.quarkiverse.cxf",
@@ -188,7 +189,7 @@ public class DevModeTest {
         CountDownLatch started = new CountDownLatch(1);
 
         try (org.cliassured.CommandProcess mvnProcess = mvn
-                .args(args(activeProfiles, settingsPath,
+                .args(args(activeProfiles, settingsPath, userProperties,
                         "quarkus:dev",
                         "-ntp"))
                 .cd(tempProject)
@@ -220,12 +221,19 @@ public class DevModeTest {
 
     }
 
-    static String[] args(String activeProfiles, Path settingsPath, String... mainArgs) {
+    static String[] args(String activeProfiles, Path settingsPath, String userProperties, String... mainArgs) {
         List<String> args = new ArrayList<>(Arrays.asList(mainArgs));
         args.add("-s");
         args.add(settingsPath.toString());
         if (activeProfiles != null && !activeProfiles.isEmpty()) {
             args.add("-P" + activeProfiles);
+        }
+        if (userProperties != null && !userProperties.isEmpty()) {
+            for (String prop : userProperties.split(" ")) {
+                if (!prop.isEmpty()) {
+                    args.add(prop);
+                }
+            }
         }
         return args.toArray(new String[0]);
     }


### PR DESCRIPTION
Use -Dqcxf.maven.user.properties.prefixes to specify which user properties should be propagated to quarkus:create and quarkus:dev child processes.