### PR TITLE
Stop managing commons-collections:commons-collections once jaxb-tools stops depending on it

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -26,11 +26,6 @@
                 <scope>import</scope>
             </dependency>
 
-			<dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>${commons-collections.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-core</artifactId>

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
   attributes:
 
     # Versions
-    quarkus-version: 3.35.1 # replace ${quarkus.version}
+    quarkus-version: 3.35.2 # replace ${quarkus.version}
     quarkus-cxf-version: 3.35.1 # replace ${release.current-version}
 
     # Toggle whether some page elements are rendered

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <awaitility.version>4.3.0</awaitility.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.awaitility:awaitility -->
         <cli-assured.version>0.0.1</cli-assured.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version><!-- Transitive of org.jvnet.jaxb:jaxb-plugins -->
-        <commons-collections.version>3.2.2</commons-collections.version>
         <cxf.xjcplugins.version>4.1.2</cxf.xjcplugins.version><!-- @sync org.apache.cxf:cxf:${cxf.version} prop:cxf.xjc-utils.version -->
         <ehcache.version>3.12.0</ehcache.version>
         <fastinfoset.version>2.1.1</fastinfoset.version>


### PR DESCRIPTION
Fix #2075