### PR TITLE
Revert "Workaround https://issues.apache.org/jira/browse/CXF-9214 WSDLs and XSDs cannot be loaded from class path on GraalVM, see also https://github.com/apache/cxf/pull/3124"

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -709,17 +709,6 @@ class QuarkusCxfProcessor {
                 classes));
     }
 
-    /**
-     * Remove once https://github.com/apache/cxf/pull/3124 reaches us
-     *
-     * @param recorder
-     */
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
-    @Record(ExecutionTime.RUNTIME_INIT)
-    void workaroundCxf9214(CXFRecorder recorder) {
-        recorder.workaroundCxf9214();
-    }
-
     private static final class NoOpEntityResolver implements EntityResolver {
         @Override
         public InputSource resolveEntity(String publicId, String systemId) {

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
@@ -340,18 +340,4 @@ public class CXFRecorder {
         });
     }
 
-    /**
-     * Remove once https://github.com/apache/cxf/pull/3124 reaches us
-     *
-     * @param recorder
-     */
-    public void workaroundCxf9214() {
-        String val = System.getProperty("org.apache.cxf.resource.uriresolver.allowedSchemes");
-        if (val != null && !val.isBlank()) {
-            System.setProperty("org.apache.cxf.resource.uriresolver.allowedSchemes", val + ",resource");
-        } else {
-            System.setProperty("org.apache.cxf.resource.uriresolver.allowedSchemes", "resource");
-        }
-    }
-
 }


### PR DESCRIPTION
This reverts commit 9167a58fd7889996f23cce26817d3844769ee6ba.