### PR TITLE
Introduce quarkus.cxf.endpoint.addressing.decoupled.enabled and quarkus.cxf.endpoint.addressing.decoupled.allowed-schemes configuration parameters

### DIFF
--- a/docs/modules/ROOT/examples/client-server/application.properties
+++ b/docs/modules/ROOT/examples/client-server/application.properties
@@ -20,6 +20,8 @@ quarkus.cxf.path = /soap
 # Addressing tests
 quarkus.cxf.endpoint."/addressing-anonymous".implementor = io.quarkiverse.cxf.it.ws.addressing.server.anonymous.AddressingAnonymousImpl
 quarkus.cxf.endpoint."/addressing-decoupled".implementor = io.quarkiverse.cxf.it.ws.addressing.server.decoupled.WsAddressingImpl
+quarkus.cxf.endpoint.addressing.decoupled.enabled = true
+quarkus.cxf.endpoint.addressing.decoupled.allowed-schemes = https://,http://
 
 quarkus.cxf.client.addressingSoapHeadersSent.client-endpoint-url = http://localhost:${quarkus.http.test-port}/soap/addressing-anonymous
 quarkus.cxf.client.addressingSoapHeadersSent.wsdl = http://localhost:${quarkus.http.test-port}/soap/addressing-anonymous?wsdl

--- a/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf.adoc
@@ -554,6 +554,42 @@ public class MyRestEasyResource {
 *Environment variable*: `+++QUARKUS_CXF_DECOUPLED_ENDPOINT_BASE+++` +
 *Since Quarkus CXF*: 2.7.0
 
+.<| [[quarkus-cxf_quarkus-cxf-endpoint-addressing-decoupled-enabled]]`link:#quarkus-cxf_quarkus-cxf-endpoint-addressing-decoupled-enabled[quarkus.cxf.endpoint.addressing.decoupled.enabled]`
+.<| `boolean`
+.<| `false`
+
+3+a|If `true`, WS-Addressing decoupled destinations (non-anonymous `wsa:ReplyTo` or `wsa:FaultTo) requested
+by clients will be honored; otherwise, any request will end result in `DestinationUnreachable` fault
+to prevent Server-Side Request Forgery (SSRF).
+Set to {@code true} only when your application legitimately requires decoupled WS-Addressing callbacks.
+
+This configuration option replaces the system property `org.apache.cxf.ws.addressing.decoupled.enabled`
+of plain CXF.
+Any Quarkus CXF application will fail to start if `org.apache.cxf.ws.addressing.decoupled.enabled` system
+property is set.
+
+*Environment variable*: `+++QUARKUS_CXF_ENDPOINT_ADDRESSING_DECOUPLED_ENABLED+++` +
+*Since Quarkus CXF*: 3.38.0
+
+.<| [[quarkus-cxf_quarkus-cxf-endpoint-addressing-decoupled-allowed-schemes]]`link:#quarkus-cxf_quarkus-cxf-endpoint-addressing-decoupled-allowed-schemes[quarkus.cxf.endpoint.addressing.decoupled.allowed-schemes]`
+.<| List of ``string``
+.<| `\https://`
+
+3+a|List of URI scheme prefixes permitted in `wsa:ReplyTo` and `wsa:FaultTo` decoupled-destination addresses.
+Replaces the functionality of `org.apache.cxf.ws.addressing.decoupled.allowedSchemes` system property used
+by plain CXF.
+Any Quarkus CXF application will fail to start if `org.apache.cxf.ws.addressing.decoupled.allowedSchemes` system
+property is set.
+
+[NOTE]
+====
+Unlike plain CXF, that allows a broader range of allowed schemes by default, Quarkus CXF allows only `https://`
+by default.
+====
+
+*Environment variable*: `+++QUARKUS_CXF_ENDPOINT_ADDRESSING_DECOUPLED_ALLOWED_SCHEMES+++` +
+*Since Quarkus CXF*: 3.38.0
+
 .<| [[quarkus-cxf_quarkus-cxf-client-tls-configuration-name]]`link:#quarkus-cxf_quarkus-cxf-client-tls-configuration-name[quarkus.cxf.client.tls-configuration-name]`
 .<| `string`
 .<| `javax.net.ssl`

--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -196,6 +196,26 @@ class QuarkusCxfProcessor {
                 .produce(new SystemPropertyBuildItem(BusFactory.BUS_FACTORY_PROPERTY_NAME, QuarkusBusFactory.class.getName()));
     }
 
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep
+    void addressingProperties(
+            CXFRecorder recorder,
+            /*
+             * The SystemPropertyBuildItem is requested
+             * so that the recorder method is called very early
+             */
+            BuildProducer<SystemPropertyBuildItem> systemProperty) {
+        recorder.addressingProperties();
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void resetAddressingProperties(
+            CXFRecorder recorder,
+            ShutdownContextBuildItem shutdownContext) {
+        recorder.resetAddressingProperties(shutdownContext);
+    }
+
     @BuildStep
     void generateRuntimeBusServiceFile(BuildProducer<GeneratedResourceBuildItem> generatedResources) {
         /*

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
@@ -2,11 +2,15 @@ package io.quarkiverse.cxf;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.io.CachedConstants;
@@ -337,6 +341,57 @@ public class CXFRecorder {
             config.directory().ifPresent(dir -> bus.setProperty(CachedConstants.OUTPUT_DIRECTORY_BUS_PROP, dir));
             bus.setProperty(CachedConstants.CLEANER_DELAY_BUS_PROP, config.gcDelay().toMillis());
             bus.setProperty(CachedConstants.CLEANER_CLEAN_ON_SHUTDOWN_BUS_PROP, config.gcOnShutDown());
+        });
+    }
+
+    private final Map<String, String> originalAddressingProperties = new ConcurrentHashMap<>();
+
+    public void addressingProperties() {
+        String message = Stream
+                .of("org.apache.cxf.ws.addressing.decoupled.enabled", "org.apache.cxf.ws.addressing.decoupled.allowedSchemes")
+                .map(prop -> new AbstractMap.SimpleImmutableEntry<>(prop, System.getProperty(prop)))
+                .peek(en -> {
+                    if (en.getValue() == null) {
+                        originalAddressingProperties.remove(en.getKey());
+                    } else {
+                        originalAddressingProperties.put(en.getKey(), en.getValue());
+                    }
+                })
+                .filter(en -> en.getValue() != null)
+                .map(en -> "Unsupported system property " + en.getKey() + ". Use Quarkus CXF configuration parameter "
+                        + en.getKey().replace("org.apache.cxf.ws.addressing.decoupled.",
+                                "quarkus.cxf.endpoint.addressing.decoupled.")
+                        + " instead.")
+                .collect(Collectors.joining("\n"));
+
+        if (message != null && !message.isEmpty()) {
+            throw new IllegalStateException(message);
+        }
+
+        System.setProperty("org.apache.cxf.ws.addressing.decoupled.enabled",
+                String.valueOf(cxfConfig.getValue().endpoint().addressing().decoupledEnabled()));
+        System.setProperty("org.apache.cxf.ws.addressing.decoupled.allowedSchemes", cxfConfig.getValue().endpoint().addressing()
+                .decoupledAllowedSchemes().stream().collect(Collectors.joining(",")));
+    }
+
+    public void resetAddressingProperties(ShutdownContext context) {
+        /*
+         * This is needed, because all QuarkusUnitTests run in the same VM.
+         * So the the stale system properties set in addressingProperties() would make the subsequent tests fail.
+         */
+        context.addShutdownTask(() -> {
+            Stream
+                    .of("org.apache.cxf.ws.addressing.decoupled.enabled",
+                            "org.apache.cxf.ws.addressing.decoupled.allowedSchemes")
+                    .forEach(key -> {
+                        String val = originalAddressingProperties.get(key);
+                        if (val == null) {
+                            System.getProperties().remove(key);
+                        } else {
+                            System.setProperty(key, val);
+                        }
+                    });
+            originalAddressingProperties.clear();
         });
     }
 

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfConfig.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfConfig.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.cxf;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -86,6 +87,14 @@ public interface CxfConfig {
      */
     // @formatter:on
     public Optional<String> decoupledEndpointBase();
+
+    /**
+     * Global service endpoint configuration
+     *
+     * @since 3.38.0
+     * @asciidoclet
+     */
+    GlobalEndpoingConfig endpoint();
 
     /**
      * Choose the path of each web services.
@@ -328,6 +337,68 @@ public interface CxfConfig {
         @WithDefault("true")
         public boolean gcOnShutDown();
 
+    }
+
+    /**
+     * Global service endpoint configuration
+     *
+     * @since 3.38.0
+     * @asciidoclet
+     */
+    public interface GlobalEndpoingConfig {
+        /**
+         * WS-Addressing configuration
+         *
+         * @since 3.38.0
+         * @asciidoclet
+         */
+        AddressingConfig addressing();
+
+        /**
+         * WS-Addressing configuration
+         *
+         * @since 3.38.0
+         * @asciidoclet
+         */
+        public interface AddressingConfig {
+            /**
+             * If `true`, WS-Addressing decoupled destinations (non-anonymous `wsa:ReplyTo` or `wsa:FaultTo) requested
+             * by clients will be honored; otherwise, any request will end result in `DestinationUnreachable` fault
+             * to prevent Server-Side Request Forgery (SSRF).
+             * Set to {@code true} only when your application legitimately requires decoupled WS-Addressing callbacks.
+             *
+             * This configuration option replaces the system property `org.apache.cxf.ws.addressing.decoupled.enabled`
+             * of plain CXF.
+             * Any Quarkus CXF application will fail to start if `org.apache.cxf.ws.addressing.decoupled.enabled` system
+             * property is set.
+             *
+             * @since 3.38.0
+             * @asciidoclet
+             */
+            @WithDefault("false")
+            @WithName("decoupled.enabled")
+            boolean decoupledEnabled();
+
+            /**
+             * List of URI scheme prefixes permitted in `wsa:ReplyTo` and `wsa:FaultTo` decoupled-destination addresses.
+             * Replaces the functionality of `org.apache.cxf.ws.addressing.decoupled.allowedSchemes` system property used
+             * by plain CXF.
+             * Any Quarkus CXF application will fail to start if `org.apache.cxf.ws.addressing.decoupled.allowedSchemes` system
+             * property is set.
+             *
+             * [NOTE]
+             * ====
+             * Unlike plain CXF, that allows a broader range of allowed schemes by default, Quarkus CXF allows only `https://`
+             * by default.
+             * ====
+             *
+             * @since 3.38.0
+             * @asciidoclet
+             */
+            @WithDefault("https://")
+            @WithName("decoupled.allowed-schemes")
+            List<String> decoupledAllowedSchemes();
+        }
     }
 
 }

--- a/integration-tests/client-server/src/main/resources/application.properties
+++ b/integration-tests/client-server/src/main/resources/application.properties
@@ -20,6 +20,8 @@ quarkus.cxf.path = /soap
 # Addressing tests
 quarkus.cxf.endpoint."/addressing-anonymous".implementor = io.quarkiverse.cxf.it.ws.addressing.server.anonymous.AddressingAnonymousImpl
 quarkus.cxf.endpoint."/addressing-decoupled".implementor = io.quarkiverse.cxf.it.ws.addressing.server.decoupled.WsAddressingImpl
+quarkus.cxf.endpoint.addressing.decoupled.enabled = true
+quarkus.cxf.endpoint.addressing.decoupled.allowed-schemes = https://,http://
 
 quarkus.cxf.client.addressingSoapHeadersSent.client-endpoint-url = http://localhost:${quarkus.http.test-port}/soap/addressing-anonymous
 quarkus.cxf.client.addressingSoapHeadersSent.wsdl = http://localhost:${quarkus.http.test-port}/soap/addressing-anonymous?wsdl


### PR DESCRIPTION
 to make Quarkus CXF work with the changes in https://github.com/apache/cxf/pull/3279