### PR TITLE
Fixup Introduce quarkus.cxf.endpoint.addressing.decoupled.enabled and quarkus.cxf.endpoint.addressing.decoupled.allowed-schemes configuration parameters

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quarkus-cxf.adoc
@@ -573,7 +573,7 @@ property is set.
 
 .<| [[quarkus-cxf_quarkus-cxf-endpoint-addressing-decoupled-allowed-schemes]]`link:#quarkus-cxf_quarkus-cxf-endpoint-addressing-decoupled-allowed-schemes[quarkus.cxf.endpoint.addressing.decoupled.allowed-schemes]`
 .<| List of ``string``
-.<| `\https://`
+.<| `\http://,https://`
 
 3+a|List of URI scheme prefixes permitted in `wsa:ReplyTo` and `wsa:FaultTo` decoupled-destination addresses.
 Replaces the functionality of `org.apache.cxf.ws.addressing.decoupled.allowedSchemes` system property used
@@ -583,8 +583,8 @@ property is set.
 
 [NOTE]
 ====
-Unlike plain CXF, that allows a broader range of allowed schemes by default, Quarkus CXF allows only `https://`
-by default.
+Unlike plain CXF, that allows a broader range of allowed schemes by default, Quarkus CXF allows only
+`http://` and `https://` by default.
 ====
 
 *Environment variable*: `+++QUARKUS_CXF_ENDPOINT_ADDRESSING_DECOUPLED_ALLOWED_SCHEMES+++` +

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfConfig.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfConfig.java
@@ -388,14 +388,14 @@ public interface CxfConfig {
              *
              * [NOTE]
              * ====
-             * Unlike plain CXF, that allows a broader range of allowed schemes by default, Quarkus CXF allows only `https://`
-             * by default.
+             * Unlike plain CXF, that allows a broader range of allowed schemes by default, Quarkus CXF allows only
+             * `http://` and `https://` by default.
              * ====
              *
              * @since 3.38.0
              * @asciidoclet
              */
-            @WithDefault("https://")
+            @WithDefault("http://,https://")
             @WithName("decoupled.allowed-schemes")
             List<String> decoupledAllowedSchemes();
         }


### PR DESCRIPTION
 to make Quarkus CXF work with the changes in https://github.com/apache/cxf/pull/3279